### PR TITLE
Fix: Mitigate CORS vulnerability

### DIFF
--- a/whisperlivekit/basic_server.py
+++ b/whisperlivekit/basic_server.py
@@ -28,7 +28,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
This commit fixes a Cross-Origin Resource Sharing (CORS) vulnerability by restricting the `allow_origins` in `CORSMiddleware` to an empty list. Previously, it was set to `["*"]`, allowing access from any origin, which is a security risk. By setting it to an empty list, CORS is effectively disabled by default, providing a more secure configuration. Users can then explicitly configure trusted origins as needed.