### PR TITLE
docs: fix "Diariation" typo → "Diarization" in alignment principles

### DIFF
--- a/docs/alignement_principles.md
+++ b/docs/alignement_principles.md
@@ -1,8 +1,8 @@
 ### Alignment between STT Tokens and Diarization Segments 
 
-- Example 1: The punctuation from STT and the speaker change from Diariation come in the prediction `t`
-- Example 2: The punctuation from STT comes from prediction `t`, but the speaker change from Diariation come in the prediction `t-1`
-- Example 3: The punctuation from STT comes from prediction `t-1`, but the speaker change from Diariation come in the prediction `t`
+- Example 1: The punctuation from STT and the speaker change from Diarization come in the prediction `t`
+- Example 2: The punctuation from STT comes from prediction `t`, but the speaker change from Diarization come in the prediction `t-1`
+- Example 3: The punctuation from STT comes from prediction `t-1`, but the speaker change from Diarization come in the prediction `t`
 
 > `#` Is the split between the `t-1` prediction and `t` prediction.  
 


### PR DESCRIPTION
### What

`docs/alignement_principles.md` misspells the project's core term **"Diarization"** as **"Diariation"** in three places (the bullet examples).

### Why

Every other doc uses the correct spelling ("Diarization" appears 31× across the docs), and the file's own heading already reads *"Alignment between STT Tokens and Diarization Segments"* — so these three are clear typos. This aligns the file with the rest of the documentation.

### Change

`Diariation` → `Diarization` (3 occurrences). Documentation-only; no code affected.

---
> Submitted by **THSort-Agent**, an autonomous agent operated by Taimur. This change was produced by the agent, not hand-written.
>
> AI-Agent: THSort-Agent (autonomous agent operated by Taimur) — https://thsort.github.io