### PR TITLE
fix(mlx): pin MLX encoder output to the decoder device (MPS/CPU mismatch with torch>=2.13)

### DIFF
--- a/whisperlivekit/simul_whisper/simul_whisper.py
+++ b/whisperlivekit/simul_whisper/simul_whisper.py
@@ -322,7 +322,12 @@ class AlignAtt(AlignAttBase):
             )
             mlx_mel = mlx_pad_or_trim(mlx_mel_padded, N_FRAMES, axis=-2)
             mlx_encoder_feature = self.mlx_encoder.encoder(mlx_mel[None])
-            encoder_feature = torch.as_tensor(mlx_encoder_feature)
+            # torch>=2.13 converts MLX arrays via DLPack onto MPS, but the
+            # decoder weights live on self.device — pin the device explicitly,
+            # like the CoreML branch above.
+            encoder_feature = torch.as_tensor(
+                np.asarray(mlx_encoder_feature), device=self.device,
+            )
             content_mel_len = int((mlx_mel_padded.shape[0] - mlx_mel.shape[0]) / 2)
         elif self.fw_encoder:
             audio_length_seconds = len(input_segments) / 16000


### PR DESCRIPTION
## Problem

On Apple Silicon with **torch >= 2.13** and `--backend mlx-whisper` (hybrid MLX-encoder / PyTorch-decoder mode), every session fails with:

```
ERROR:whisperlivekit.simul_whisper.align_att_base:Model warmup failed: Tensor for argument weight is on cpu but expected on mps
```

The server starts and reports healthy, but all sessions yield **empty captions** while `remaining_time_transcription` grows unbounded — so the failure is easy to miss.

## Cause

`_encode()` converts the MLX encoder output with `torch.as_tensor(mlx_encoder_feature)` (no `device=`). Since torch 2.13, MLX arrays convert zero-copy via DLPack and the resulting tensor lands on `mps:0`, while the hybrid-mode Whisper decoder is loaded on CPU (`load_model` picks `cuda if available else cpu`).

Minimal repro:

```bash
python -c 'import mlx.core as mx, torch; print(torch.as_tensor(mx.array([1.0])).device)'
# torch 2.13.0 -> mps:0
```

## Fix

Convert through numpy with an explicit `device=self.device`, mirroring what the CoreML branch a few lines above already does.

## Verified

Reproduced and verified on macOS 26.5.1 (M-series), Python 3.13.14, torch 2.13.0, mlx-whisper 0.4.3, model `large-v3-turbo`: warmup failed with empty captions before the change; after it, live transcription of 16 kHz PCM over `/asr` works with correct partials/finals in en/nl/de/fr/es test clips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)