### PR TITLE
Add FunASR SenseVoiceSmall backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
           cache: pip
 
       - name: Install package with test deps
-        run: pip install -e ".[test,funasr]" qwen3-asr-causal
+        run: pip install -e ".[test]" qwen3-asr-causal
 
-      # The full backend matrix in test_pipeline.py remains local (see CLAUDE.md).
-      # The normal suite includes a pinned SenseVoiceSmall TestHarness smoke test.
+      # test_pipeline.py downloads real models and audio; it stays a local
+      # suite (see CLAUDE.md). CI runs the dependency-light tests.
       - name: Run test suite
         run: pytest -q tests/ --ignore=tests/test_pipeline.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
           cache: pip
 
       - name: Install package with test deps
-        run: pip install -e ".[test]" qwen3-asr-causal
+        run: pip install -e ".[test,funasr]" qwen3-asr-causal
 
-      # test_pipeline.py downloads real models and audio; it stays a local
-      # suite (see CLAUDE.md). CI runs the dependency-light tests.
+      # The full backend matrix in test_pipeline.py remains local (see CLAUDE.md).
+      # The normal suite includes a pinned SenseVoiceSmall TestHarness smoke test.
       - name: Run test suite
         run: pytest -q tests/ --ignore=tests/test_pipeline.py

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ For a native SwiftUI macOS client, see [macos/WhisperLiveKitMac](macos/WhisperLi
 | Feature | `uv sync` | `pip install -e` |
 |-----------|-------------|-------------|
 | **Apple Silicon MLX Whisper backend** | `uv sync --extra mlx-whisper` | `pip install -e ".[mlx-whisper]"` |
+| **FunASR SenseVoiceSmall** | `uv sync --extra funasr` | `pip install -e ".[funasr]"` |
 | **Voxtral (MLX backend, Apple Silicon)** | `uv sync --extra voxtral-mlx` | `pip install -e ".[voxtral-mlx]"` |
 | **CPU PyTorch stack** | `uv sync --extra cpu` | `pip install -e ".[cpu]"` |
 | **CUDA 12.9 PyTorch stack** | `uv sync --extra cu129` | `pip install -e ".[cu129]"` |
@@ -181,6 +182,32 @@ wlk --backend voxtral
 
 Voxtral uses its own streaming policy and does not use LocalAgreement or SimulStreaming.
 See [BENCHMARK.md](BENCHMARK.md) for performance numbers.
+
+### FunASR / SenseVoiceSmall
+
+Install the optional backend and run
+[SenseVoiceSmall](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) through
+WLK's existing LocalAgreement and VAC/VAD pipeline:
+
+```bash
+pip install "whisperlivekit[funasr]"
+wlk --backend funasr --language auto
+```
+
+Use a verified local model snapshot without executing remote model code:
+
+```bash
+wlk --backend funasr --model_dir /path/to/SenseVoiceSmall --language yue
+```
+
+The initial integration supports SenseVoiceSmall transcription in Mandarin
+(`zh`), Cantonese (`yue`), English (`en`), Japanese (`ja`), Korean (`ko`), and
+automatic detection. FunASR uses LocalAgreement only; selecting it with the
+default policy switches that policy automatically. It does not support
+`--direct-english-translation`, and WLK remains responsible for voice activity
+control rather than enabling FunASR's internal VAD. This compatibility contract
+does not cover arbitrary FunASR models. SenseVoiceSmall is distributed under
+its [model license](https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE).
 
 ### Qwen3-ASR streaming (HF Transformers)
 
@@ -334,7 +361,7 @@ async def websocket_endpoint(websocket: WebSocket):
 | `--translation-backend` | `nllb` (in-process, CPU-friendly) or `alignatt`: streaming LLM translation through an [Alignatt4LLM](https://github.com/QuentinFuxa/Alignatt4LLM) sidecar, with attention-gated append-only commits. See [docs/translation-alignatt.md](docs/translation-alignatt.md). | `nllb` |
 | `--diarization` | Enable speaker identification | `False` |
 | `--backend-policy` | Streaming strategy: `1`/`simulstreaming` uses AlignAtt SimulStreaming, `2`/`localagreement` uses the LocalAgreement policy | `simulstreaming` |
-| `--backend` | ASR backend selector. `auto` picks MLX on macOS (if installed), otherwise Faster-Whisper, otherwise vanilla Whisper. Options: `mlx-whisper`, `faster-whisper`, `whisper`, `openai-api` (LocalAgreement only), `voxtral-mlx` (Apple Silicon), `voxtral` (HuggingFace), `qwen3-vllm`, `qwen3-vllm-metal` (Apple Silicon), `qwen3-streaming` (HuggingFace, CUDA/MPS/CPU) | `auto` |
+| `--backend` | ASR backend selector. `auto` picks MLX on macOS (if installed), otherwise Faster-Whisper, otherwise vanilla Whisper. Options: `mlx-whisper`, `faster-whisper`, `whisper`, `openai-api` (LocalAgreement only), `funasr` (SenseVoiceSmall, LocalAgreement only), `voxtral-mlx` (Apple Silicon), `voxtral` (HuggingFace), `qwen3-vllm`, `qwen3-vllm-metal` (Apple Silicon), `qwen3-streaming` (HuggingFace, CUDA/MPS/CPU) | `auto` |
 | `--no-vac` | Disable Voice Activity Controller. NOT ADVISED | `False` |
 | `--no-vad` | Disable Voice Activity Detection. NOT ADVISED | `False` |
 | `--warmup-file` | Audio file path for model warmup | `jfk.wav` |

--- a/docs/default_and_custom_models.md
+++ b/docs/default_and_custom_models.md
@@ -14,6 +14,18 @@ When translation is enabled, the 600M distilled NLLB model is used by default. T
 **Default Translation Backend**: `transformers`  
 The translation backend defaults to Transformers. On Apple Silicon, this automatically uses MPS acceleration for better performance.
 
+## FunASR SenseVoiceSmall
+
+`--backend funasr` maps WLK's unchanged default model name to
+`iic/SenseVoiceSmall`. `--model_dir` takes precedence and may point to a local
+SenseVoiceSmall snapshot. WLK passes 16 kHz mono audio to FunASR with word
+timestamps enabled and `trust_remote_code=False`; the initial compatibility
+contract does not cover arbitrary FunASR models.
+
+SenseVoiceSmall runs through WLK's LocalAgreement policy. It supports `auto`,
+`zh`, `yue`, `en`, `ja`, and `ko`, while WLK's VAC/VAD pipeline remains
+responsible for speech boundaries.
+
 ---
 
 

--- a/docs/supported_languages.md
+++ b/docs/supported_languages.md
@@ -2,6 +2,10 @@
 
 WLK supports transcription in the following languages:
 
+The FunASR SenseVoiceSmall backend supports `auto`, `zh`, `yue`, `en`, `ja`,
+and `ko`. These backend-specific limits are narrower than Whisper's language
+list; unsupported values are rejected during configuration.
+
 | ISO Code | Language Name        |
 |----------|---------------------|
 | en       | English             |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 test = ["pytest>=7.0", "pytest-asyncio>=0.21", "datasets>=2.14", "librosa"]
 translation = ["nllw"]
 sentence_tokenizer = ["mosestokenizer", "wtpsplit"]
+funasr = ["funasr~=1.3.14"]
 mlx-whisper = [
     'mlx>=0.11.0; sys_platform == "darwin" and platform_machine == "arm64"',
     'mlx-whisper>=0.4.0; sys_platform == "darwin" and platform_machine == "arm64"',

--- a/tests/test_funasr_backend.py
+++ b/tests/test_funasr_backend.py
@@ -56,6 +56,18 @@ def _adapter_for_tokens(postprocessed_text, language=None):
     return asr
 
 
+def test_funasr_backend_declares_sampling_rate():
+    from whisperlivekit.funasr_backend import FunASRASR
+
+    assert FunASRASR.SAMPLING_RATE == 16000
+
+
+def test_funasr_does_not_extend_whisper_language_table():
+    from whisperlivekit.local_agreement.whisper_online import WHISPER_LANG_CODES
+
+    assert "yue" not in WHISPER_LANG_CODES
+
+
 @pytest.mark.parametrize(
     ("text", "words", "expected_parts"),
     [
@@ -227,6 +239,26 @@ def test_funasr_empty_result_stays_empty(result):
     asr = _adapter_for_tokens("")
     assert asr.ts_words(result) == []
     assert asr.segments_end_ts(result) == []
+
+
+def test_funasr_decoration_only_output_stays_empty():
+    asr = _adapter_for_tokens("")
+    result = [{"text": "<|en|><|NEUTRAL|><|Music|><|woitn|>", "words": [], "timestamp": []}]
+
+    assert asr.ts_words(result) == []
+    assert asr.segments_end_ts(result) == []
+
+
+def test_funasr_session_rejects_unsupported_language():
+    from types import SimpleNamespace
+
+    from whisperlivekit.core import online_factory
+
+    asr = SimpleNamespace(backend_choice="funasr")
+    args = SimpleNamespace(backend="funasr")
+
+    with pytest.raises(ValueError, match="supports only"):
+        online_factory(args, asr, language="fr")
 
 
 def test_funasr_segment_end_uses_last_word_timestamp():

--- a/tests/test_funasr_backend.py
+++ b/tests/test_funasr_backend.py
@@ -1,0 +1,258 @@
+import logging
+
+import pytest
+
+from whisperlivekit.config import WhisperLiveKitConfig
+
+
+def test_funasr_config_normalizes_to_localagreement(caplog):
+    with caplog.at_level(logging.WARNING, logger="whisperlivekit.config"):
+        config = WhisperLiveKitConfig(backend="funasr")
+
+    assert config.backend_policy == "localagreement"
+    assert "requires LocalAgreement" in caplog.text
+
+
+@pytest.mark.parametrize("language", ["auto", "zh", "yue", "en", "ja", "ko"])
+def test_funasr_config_accepts_supported_languages(language):
+    config = WhisperLiveKitConfig(
+        backend="funasr", backend_policy="localagreement", lan=language
+    )
+    assert config.lan == language
+
+
+def test_funasr_config_rejects_unsupported_language():
+    with pytest.raises(ValueError, match="supports only"):
+        WhisperLiveKitConfig(
+            backend="funasr", backend_policy="localagreement", lan="fr"
+        )
+
+
+def test_funasr_config_rejects_direct_translation():
+    with pytest.raises(ValueError, match="direct English translation"):
+        WhisperLiveKitConfig(
+            backend="funasr",
+            backend_policy="localagreement",
+            direct_english_translation=True,
+        )
+
+
+def test_funasr_sentence_trimming_requires_explicit_language():
+    with pytest.raises(ValueError, match="explicit language"):
+        WhisperLiveKitConfig(
+            backend="funasr",
+            backend_policy="localagreement",
+            lan="auto",
+            buffer_trimming="sentence",
+        )
+
+
+def _adapter_for_tokens(postprocessed_text, language=None):
+    from whisperlivekit.funasr_backend import FunASRASR
+
+    asr = FunASRASR.__new__(FunASRASR)
+    asr.original_language = language
+    asr._postprocess = lambda _raw: postprocessed_text
+    return asr
+
+
+@pytest.mark.parametrize(
+    ("text", "words", "expected_parts"),
+    [
+        (
+            "The tribal chief called for 50 pieces.",
+            ["The", "tribal", "chief", "called", "for", "5", "0", "pieces"],
+            [
+                "The",
+                " tribal",
+                " chief",
+                " called",
+                " for",
+                " 5",
+                "0",
+                " pieces.",
+            ],
+        ),
+        (
+            "开饭时间早上9点至下午5点。",
+            ["开", "饭", "时", "间", "早", "上", "9", "点", "至", "下", "午", "5", "点"],
+            ["开", "饭", "时", "间", "早", "上", "9", "点", "至", "下", "午", "5", "点。"],
+        ),
+        (
+            "呢几个字，都表达唔到我想讲嘅意思。",
+            ["呢", "几", "个", "字", "都", "表", "达", "唔", "到", "我", "想", "讲", "嘅", "意", "思"],
+            ["呢", "几", "个", "字，", "都", "表", "达", "唔", "到", "我", "想", "讲", "嘅", "意", "思。"],
+        ),
+        (
+            "조금만 생각을 하면서 살면 편할 거야.",
+            ["조금만", "생각을", "하면서", "살면", "편할", "거야"],
+            ["조금만", " 생각을", " 하면서", " 살면", " 편할", " 거야."],
+        ),
+    ],
+)
+def test_funasr_tokens_reconstruct_postprocessed_text_exactly(
+    text, words, expected_parts
+):
+    asr = _adapter_for_tokens(text)
+    timestamps = [
+        [index * 100, (index + 1) * 100] for index in range(len(words))
+    ]
+    result = [{"text": "raw", "words": words, "timestamp": timestamps}]
+
+    tokens = asr.ts_words(result)
+
+    assert [token.text for token in tokens] == expected_parts
+    assert "".join(token.text for token in tokens) == text
+    assert [(token.start, token.end) for token in tokens] == [
+        (index / 10, (index + 1) / 10) for index in range(len(words))
+    ]
+
+
+def test_funasr_tokens_propagate_detected_language_from_control_tag():
+    asr = _adapter_for_tokens("hello")
+    tokens = asr.ts_words(
+        [
+            {
+                "text": "<|en|><|NEUTRAL|><|Speech|><|woitn|>hello",
+                "words": ["hello"],
+                "timestamp": [[0, 500]],
+            }
+        ]
+    )
+    assert tokens[0].detected_language == "en"
+
+
+def test_funasr_explicit_language_wins_over_control_tag():
+    asr = _adapter_for_tokens("hello", language="ko")
+    tokens = asr.ts_words(
+        [
+            {
+                "text": "<|en|>hello",
+                "words": ["hello"],
+                "timestamp": [[0, 500]],
+            }
+        ]
+    )
+    assert tokens[0].detected_language == "ko"
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        [{}],
+        [{"text": "", "words": []}],
+        [{"text": "", "timestamp": []}],
+        [{"words": [], "timestamp": []}],
+    ],
+)
+def test_funasr_missing_result_fields_fail_closed(result):
+    asr = _adapter_for_tokens("")
+    with pytest.raises(ValueError, match="missing required field"):
+        asr.ts_words(result)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        [{"text": "", "words": None, "timestamp": []}],
+        [{"text": "", "words": [], "timestamp": None}],
+    ],
+)
+def test_funasr_invalid_empty_result_containers_fail_closed(result):
+    asr = _adapter_for_tokens("")
+    with pytest.raises(ValueError, match="must be a list"):
+        asr.ts_words(result)
+
+
+@pytest.mark.parametrize(
+    ("result", "message"),
+    [
+        ([{"text": "hello", "words": ["hello"], "timestamp": []}], "length"),
+        (
+            [{"text": "hello", "words": ["hello"], "timestamp": [[500, 100]]}],
+            "span",
+        ),
+        (
+            [
+                {
+                    "text": "hello world",
+                    "words": ["world", "hello"],
+                    "timestamp": [[0, 100], [100, 200]],
+                }
+            ],
+            "word index",
+        ),
+        (
+            [
+                {
+                    "text": "hello",
+                    "words": ["hello"],
+                    "timestamp": [[float("nan"), 100]],
+                }
+            ],
+            "finite",
+        ),
+        (
+            [
+                {
+                    "text": "hello world",
+                    "words": ["hello", "world"],
+                    "timestamp": [[200, 400], [100, 500]],
+                }
+            ],
+            "non-monotonic",
+        ),
+        (
+            [
+                {
+                    "text": "hello missing world",
+                    "words": ["hello", "world"],
+                    "timestamp": [[0, 100], [100, 200]],
+                }
+            ],
+            "unassigned text",
+        ),
+    ],
+)
+def test_funasr_malformed_results_fail_closed(result, message):
+    asr = _adapter_for_tokens(result[0]["text"])
+    with pytest.raises(ValueError, match=message):
+        asr.ts_words(result)
+
+
+@pytest.mark.parametrize(
+    "result", [None, [], [{"text": "", "words": [], "timestamp": []}]]
+)
+def test_funasr_empty_result_stays_empty(result):
+    asr = _adapter_for_tokens("")
+    assert asr.ts_words(result) == []
+    assert asr.segments_end_ts(result) == []
+
+
+def test_funasr_segment_end_uses_last_word_timestamp():
+    asr = _adapter_for_tokens("hello world")
+    result = [
+        {
+            "text": "raw",
+            "words": ["hello", "world"],
+            "timestamp": [[0, 250], [300, 900]],
+        }
+    ]
+    assert asr.segments_end_ts(result) == [0.9]
+
+
+def test_wlk_cli_registers_funasr_backend():
+    from whisperlivekit.cli import BACKENDS
+
+    backend = next(entry for entry in BACKENDS if entry["id"] == "funasr")
+
+    assert backend["module"] == "funasr"
+    assert backend["policy"] == "localagreement"
+
+
+def test_wlk_cli_runs_funasr_without_fake_huggingface_pull(capsys):
+    from whisperlivekit.cli import _resolve_pull_target, _resolve_run_spec
+
+    assert _resolve_run_spec("funasr") == ("funasr", None)
+    assert _resolve_pull_target("funasr") == []
+    assert capsys.readouterr().out == ""

--- a/tests/test_funasr_backend_integration.py
+++ b/tests/test_funasr_backend_integration.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -15,6 +14,11 @@ MODEL_DIR = os.environ.get("WLK_FUNASR_MODEL_DIR")
 SENSEVOICE_REPO = "FunAudioLLM/SenseVoiceSmall"
 SENSEVOICE_REVISION = "3847d57b6bdf2dd8875cb1508d2af43d80a16bf7"
 
+pytestmark = pytest.mark.skipif(
+    not RUN_INTEGRATION,
+    reason="set WLK_RUN_FUNASR_INTEGRATION=1 to run FunASR integration tests",
+)
+
 EXPECTED = {
     "en": "tribal",
     "zh": "开饭时间",
@@ -22,25 +26,6 @@ EXPECTED = {
     "ja": "中学",
     "ko": "생각",
 }
-
-
-def test_test_harness_audio_loader_falls_back_without_ffmpeg(tmp_path, monkeypatch):
-    from whisperlivekit import test_harness
-
-    sample_rate = 16000
-    audio = np.sin(np.linspace(0, np.pi * 8, sample_rate, dtype=np.float32)) * 0.2
-    sample = tmp_path / "sample.wav"
-    sf.write(sample, audio, sample_rate)
-
-    def missing_ffmpeg(*args, **kwargs):
-        raise FileNotFoundError("ffmpeg")
-
-    monkeypatch.setattr(subprocess, "run", missing_ffmpeg)
-
-    pcm = test_harness.load_audio_pcm(str(sample), sample_rate=sample_rate)
-
-    assert pcm
-    assert len(pcm) == sample_rate * 2
 
 
 def _load_16khz(path):
@@ -61,7 +46,7 @@ def _load_16khz(path):
 
 @pytest.fixture(scope="module")
 def sensevoice():
-    if not RUN_INTEGRATION or not MODEL_DIR:
+    if not MODEL_DIR:
         pytest.skip("set WLK_RUN_FUNASR_INTEGRATION=1 and WLK_FUNASR_MODEL_DIR")
     return FunASRASR(lan="auto", model_dir=MODEL_DIR)
 

--- a/tests/test_funasr_backend_integration.py
+++ b/tests/test_funasr_backend_integration.py
@@ -1,0 +1,175 @@
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from whisperlivekit.funasr_backend import FunASRASR
+from whisperlivekit.local_agreement.online_asr import OnlineASRProcessor
+from whisperlivekit.session_asr_proxy import SessionASRProxy
+
+RUN_INTEGRATION = os.environ.get("WLK_RUN_FUNASR_INTEGRATION") == "1"
+MODEL_DIR = os.environ.get("WLK_FUNASR_MODEL_DIR")
+SENSEVOICE_REPO = "FunAudioLLM/SenseVoiceSmall"
+SENSEVOICE_REVISION = "3847d57b6bdf2dd8875cb1508d2af43d80a16bf7"
+
+EXPECTED = {
+    "en": "tribal",
+    "zh": "开饭时间",
+    "yue": "表达",
+    "ja": "中学",
+    "ko": "생각",
+}
+
+
+def _load_16khz(path):
+    audio, sample_rate = sf.read(path, dtype="float32", always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    if sample_rate != 16000:
+        scipy_signal = pytest.importorskip(
+            "scipy.signal",
+            reason="resampling non-16 kHz FunASR fixtures requires scipy",
+        )
+        divisor = int(np.gcd(sample_rate, 16000))
+        audio = scipy_signal.resample_poly(
+            audio, 16000 // divisor, sample_rate // divisor
+        )
+    return np.asarray(audio, dtype=np.float32)
+
+
+@pytest.fixture(scope="module")
+def sensevoice():
+    if not RUN_INTEGRATION or not MODEL_DIR:
+        pytest.skip("set WLK_RUN_FUNASR_INTEGRATION=1 and WLK_FUNASR_MODEL_DIR")
+    return FunASRASR(lan="auto", model_dir=MODEL_DIR)
+
+
+@pytest.mark.parametrize("language", ["en", "zh", "yue", "ja", "ko"])
+def test_real_sensevoice_multilingual_timestamp_contract(sensevoice, language):
+    sample = Path(MODEL_DIR) / "example" / f"{language}.mp3"
+    audio = _load_16khz(sample)
+    result = sensevoice.transcribe(audio)
+    tokens = sensevoice.ts_words(result)
+    text = "".join(token.text for token in tokens)
+
+    assert tokens
+    assert EXPECTED[language] in text
+    assert text == sensevoice._postprocess(result[0]["text"])
+    assert len(result[0]["words"]) == len(result[0]["timestamp"]) == len(tokens)
+    assert all(np.isfinite([token.start, token.end]).all() for token in tokens)
+    assert all(token.start >= 0 and token.end >= token.start for token in tokens)
+    assert all(
+        left.start <= right.start and left.end <= right.end
+        for left, right in zip(tokens, tokens[1:])
+    )
+    assert tokens[-1].end <= len(audio) / 16000 + 0.75
+    assert {token.detected_language for token in tokens} == {language}
+
+
+def test_real_sensevoice_session_language_survives_proxy(sensevoice):
+    audio = _load_16khz(Path(MODEL_DIR) / "example" / "ko.mp3")
+    session = SessionASRProxy(sensevoice, "ko")
+
+    result = session.transcribe(audio)
+    tokens = session.ts_words(result)
+
+    assert sensevoice.original_language is None
+    assert EXPECTED["ko"] in "".join(token.text for token in tokens)
+    assert {token.detected_language for token in tokens} == {"ko"}
+
+
+def test_real_sensevoice_progressive_english_is_stable(sensevoice):
+    audio = _load_16khz(Path(MODEL_DIR) / "example" / "en.mp3")
+    hypotheses = []
+    for seconds in (3, 5, len(audio) / 16000):
+        result = sensevoice.transcribe(audio[: int(seconds * 16000)])
+        hypotheses.append([token.text for token in sensevoice.ts_words(result)])
+
+    shared_prefixes = []
+    for earlier, later in zip(hypotheses, hypotheses[1:]):
+        shared = 0
+        for left, right in zip(earlier, later):
+            if left != right:
+                break
+            shared += 1
+        shared_prefixes.append(shared)
+        assert shared >= min(5, max(1, len(earlier) - 1)), hypotheses
+
+    assert shared_prefixes == sorted(shared_prefixes)
+
+
+def test_real_sensevoice_streams_through_local_agreement(sensevoice):
+    audio = _load_16khz(Path(MODEL_DIR) / "example" / "en.mp3")
+    expected_result = sensevoice.transcribe(audio)
+    expected_text = "".join(
+        token.text for token in sensevoice.ts_words(expected_result)
+    )
+
+    sensevoice.tokenizer = None
+    sensevoice.confidence_validation = False
+    sensevoice.buffer_trimming = "segment"
+    sensevoice.buffer_trimming_sec = 15
+    online = OnlineASRProcessor(sensevoice)
+
+    boundaries = (3 * 16000, 5 * 16000, len(audio))
+    emitted = []
+    previous = 0
+    processed_upto = []
+    for boundary in boundaries:
+        online.insert_audio_chunk(audio[previous:boundary])
+        tokens, end_time = online.process_iter()
+        emitted.append(tokens)
+        processed_upto.append(end_time)
+        previous = boundary
+
+    remaining, final_time = online.finish()
+    output = [token for chunk in emitted for token in chunk] + remaining
+
+    assert not emitted[0]
+    assert len(emitted[1]) >= 5
+    assert len(emitted[2]) >= 2
+    assert "".join(token.text for token in output) == expected_text
+    assert all(
+        left.start <= right.start and left.end <= right.end
+        for left, right in zip(output, output[1:])
+    )
+    assert processed_upto == pytest.approx([3, 5, len(audio) / 16000])
+    assert final_time == pytest.approx(len(audio) / 16000)
+
+
+@pytest.mark.asyncio
+async def test_real_sensevoice_runs_through_test_harness():
+    pytest.importorskip("funasr")
+    from huggingface_hub import snapshot_download
+
+    from whisperlivekit.test_harness import TestHarness
+
+    model_dir = (
+        Path(MODEL_DIR)
+        if MODEL_DIR
+        else Path(
+            snapshot_download(
+                repo_id=SENSEVOICE_REPO,
+                revision=SENSEVOICE_REVISION,
+            )
+        )
+    )
+    sample = model_dir / "example" / "en.mp3"
+    async with TestHarness(
+        backend="funasr",
+        backend_policy="localagreement",
+        model_dir=str(model_dir),
+        lan="en",
+        vac=False,
+        warmup_file=None,
+    ) as harness:
+        await harness.feed(str(sample), speed=0, chunk_duration=1.0)
+        result = await harness.finish(timeout=90)
+
+    assert not result.error
+    assert "tribal" in result.committed_text
+    assert result.buffer_transcription == ""
+    assert result.text == result.committed_text
+    assert not result.timing_errors()

--- a/tests/test_funasr_backend_integration.py
+++ b/tests/test_funasr_backend_integration.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -21,6 +22,25 @@ EXPECTED = {
     "ja": "中学",
     "ko": "생각",
 }
+
+
+def test_test_harness_audio_loader_falls_back_without_ffmpeg(tmp_path, monkeypatch):
+    from whisperlivekit import test_harness
+
+    sample_rate = 16000
+    audio = np.sin(np.linspace(0, np.pi * 8, sample_rate, dtype=np.float32)) * 0.2
+    sample = tmp_path / "sample.wav"
+    sf.write(sample, audio, sample_rate)
+
+    def missing_ffmpeg(*args, **kwargs):
+        raise FileNotFoundError("ffmpeg")
+
+    monkeypatch.setattr(subprocess, "run", missing_ffmpeg)
+
+    pcm = test_harness.load_audio_pcm(str(sample), sample_rate=sample_rate)
+
+    assert pcm
+    assert len(pcm) == sample_rate * 2
 
 
 def _load_16khz(path):

--- a/whisperlivekit/cli.py
+++ b/whisperlivekit/cli.py
@@ -82,6 +82,16 @@ BACKENDS = [
         "devices": ["mlx"],
     },
     {
+        "id": "funasr",
+        "name": "FunASR SenseVoice",
+        "module": "funasr",
+        "install": "pip install 'whisperlivekit[funasr]'",
+        "description": "SenseVoiceSmall multilingual ASR through LocalAgreement",
+        "policy": "localagreement",
+        "streaming": "chunk",
+        "devices": ["cpu", "cuda"],
+    },
+    {
         "id": "voxtral-mlx",
         "name": "Voxtral MLX",
         "module": "mlx",
@@ -433,6 +443,7 @@ def cmd_models():
     else:
         print("    wlk run large-v3-turbo            # Best quality/speed balance")
         print("    wlk run voxtral                   # Native streaming (CUDA/CPU)")
+    print("    wlk run funasr                    # Fast multilingual SenseVoiceSmall")
     print("    wlk pull base                     # Download smallest multilingual model")
     print("    wlk transcribe audio.mp3          # Offline transcription")
     print()
@@ -464,6 +475,10 @@ def _resolve_pull_target(spec: str):
     else:
         backend_part = None
         size_part = spec
+
+    if backend_part is None and size_part == "funasr":
+        # FunASR owns its ModelScope cache; an HF pull would not populate it.
+        return targets
 
     # Handle voxtral
     if size_part == "voxtral" or backend_part == "voxtral":

--- a/whisperlivekit/config.py
+++ b/whisperlivekit/config.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+FUNASR_LANGUAGES = frozenset({"auto", "zh", "yue", "en", "ja", "ko"})
+
 
 def parse_cors_origins(origins: Optional[str]) -> list[str]:
     """Parse comma-separated CORS origins for FastAPI."""
@@ -149,14 +151,41 @@ class WhisperLiveKitConfig:
     qwen3_streaming_block_frames: int = 192
 
     def __post_init__(self):
-        # .en model suffix forces English
-        if self.model_size and self.model_size.endswith(".en"):
+        # .en model suffix forces English for Whisper-family backends.
+        if (
+            self.backend != "funasr"
+            and self.model_size
+            and self.model_size.endswith(".en")
+        ):
             self.lan = "en"
-        # Normalize backend_policy aliases
+
         if self.backend_policy == "1":
             self.backend_policy = "simulstreaming"
         elif self.backend_policy == "2":
             self.backend_policy = "localagreement"
+
+        if self.backend != "funasr":
+            return
+
+        if self.backend_policy == "simulstreaming":
+            logger.warning(
+                "FunASR requires LocalAgreement; using backend_policy=localagreement."
+            )
+            self.backend_policy = "localagreement"
+        elif self.backend_policy != "localagreement":
+            raise ValueError("FunASR requires the LocalAgreement backend policy.")
+
+        if self.lan not in FUNASR_LANGUAGES:
+            supported = ", ".join(sorted(FUNASR_LANGUAGES))
+            raise ValueError(f"FunASR SenseVoiceSmall supports only: {supported}.")
+        if self.direct_english_translation:
+            raise ValueError(
+                "FunASR SenseVoiceSmall does not support direct English translation."
+            )
+        if self.buffer_trimming == "sentence" and self.lan == "auto":
+            raise ValueError(
+                "FunASR sentence trimming requires an explicit language."
+            )
 
     # ------------------------------------------------------------------
     # Factory helpers

--- a/whisperlivekit/core.py
+++ b/whisperlivekit/core.py
@@ -330,6 +330,9 @@ def online_factory(args, asr, language=None):
     if backend == "voxtral":
         from whisperlivekit.voxtral_hf_streaming import VoxtralHFStreamingOnlineProcessor
         return VoxtralHFStreamingOnlineProcessor(asr)
+    if backend == "funasr":
+        from whisperlivekit.funasr_backend import FunASROnlineASRProcessor
+        return FunASROnlineASRProcessor(asr)
     if args.backend_policy == "simulstreaming":
         from whisperlivekit.simul_whisper import SimulStreamingOnlineProcessor
         return SimulStreamingOnlineProcessor(asr)

--- a/whisperlivekit/core.py
+++ b/whisperlivekit/core.py
@@ -301,6 +301,14 @@ def online_factory(args, asr, language=None):
     """
     # Wrap the shared ASR with a per-session language if requested
     if language is not None:
+        if getattr(args, "backend", None) == "funasr":
+            from whisperlivekit.config import FUNASR_LANGUAGES
+
+            if language not in FUNASR_LANGUAGES:
+                supported = ", ".join(sorted(FUNASR_LANGUAGES))
+                raise ValueError(
+                    f"FunASR SenseVoiceSmall supports only: {supported}."
+                )
         from whisperlivekit.session_asr_proxy import SessionASRProxy
         asr = SessionASRProxy(asr, language)
 

--- a/whisperlivekit/funasr_backend.py
+++ b/whisperlivekit/funasr_backend.py
@@ -1,0 +1,270 @@
+"""Optional FunASR/SenseVoice adapter for LocalAgreement."""
+
+import math
+import re
+import sys
+import threading
+import unicodedata
+from typing import Any
+
+from whisperlivekit.config import FUNASR_LANGUAGES
+from whisperlivekit.local_agreement.online_asr import OnlineASRProcessor
+from whisperlivekit.timed_objects import ASRToken
+
+DEFAULT_FUNASR_MODEL = "iic/SenseVoiceSmall"
+_LANGUAGE_TAG = re.compile(r"<\|(?P<language>zh|yue|en|ja|ko)\|>")
+_REQUEST_LANGUAGE_KEY = "_wlk_requested_language"
+_INSTALL_MESSAGE = (
+    "FunASR backend requested but funasr is not installed. Install it with:\n"
+    'pip install "whisperlivekit[funasr]"'
+)
+
+
+def _load_funasr_dependencies():
+    try:
+        from funasr import AutoModel
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+    except ModuleNotFoundError as exc:
+        if exc.name and not exc.name.startswith("funasr"):
+            raise
+        raise ImportError(_INSTALL_MESSAGE) from exc
+    return AutoModel, rich_transcription_postprocess
+
+
+class FunASRASR:
+    """Adapt SenseVoice's offline output to WLK's LocalAgreement contract."""
+
+    sep = ""
+
+    def __init__(
+        self,
+        lan,
+        model_size=None,
+        cache_dir=None,
+        model_dir=None,
+        logfile=sys.stderr,
+    ):
+        del model_size, cache_dir
+        auto_model, postprocess = _load_funasr_dependencies()
+        self.logfile = logfile
+        self.original_language = None if lan == "auto" else lan
+        self.transcribe_kargs = {}
+        self._postprocess = postprocess
+        self._session_lock = threading.RLock()
+        self.model_name_or_path = model_dir or DEFAULT_FUNASR_MODEL
+        try:
+            self.model = auto_model(
+                model=self.model_name_or_path,
+                trust_remote_code=False,
+                disable_update=True,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to load FunASR model from {self.model_name_or_path!r}."
+            ) from exc
+
+    def transcribe(self, audio, init_prompt=""):
+        del init_prompt
+        with self._session_lock:
+            language = self.original_language or "auto"
+            if language not in FUNASR_LANGUAGES:
+                supported = ", ".join(sorted(FUNASR_LANGUAGES))
+                raise ValueError(
+                    f"FunASR SenseVoiceSmall supports only: {supported}."
+                )
+            result = self.model.generate(
+                input=audio,
+                cache={},
+                language=language,
+                use_itn=True,
+                output_timestamp=True,
+            )
+            if (
+                isinstance(result, list)
+                and len(result) == 1
+                and isinstance(result[0], dict)
+            ):
+                result = [
+                    {
+                        **result[0],
+                        _REQUEST_LANGUAGE_KEY: None
+                        if language == "auto"
+                        else language,
+                    }
+                ]
+            return result
+
+    @staticmethod
+    def _result_item(result: Any):
+        if result is None or result == []:
+            return None
+        if (
+            not isinstance(result, list)
+            or len(result) != 1
+            or not isinstance(result[0], dict)
+        ):
+            raise ValueError("FunASR must return exactly one result object.")
+        return result[0]
+
+    @staticmethod
+    def _validated_spans(timestamps, word_count):
+        if not isinstance(timestamps, (list, tuple)) or len(timestamps) != word_count:
+            timestamp_count = (
+                len(timestamps) if isinstance(timestamps, (list, tuple)) else "invalid"
+            )
+            raise ValueError(
+                "FunASR word/timestamp length mismatch: "
+                f"{word_count} words and {timestamp_count} timestamps."
+            )
+
+        spans = []
+        previous_start = 0.0
+        previous_end = 0.0
+        for index, pair in enumerate(timestamps):
+            if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+                raise ValueError(
+                    f"Invalid FunASR timestamp span at word index {index}."
+                )
+            try:
+                start = float(pair[0]) / 1000.0
+                end = float(pair[1]) / 1000.0
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Non-numeric FunASR timestamp at word index {index}."
+                ) from exc
+            if not math.isfinite(start) or not math.isfinite(end):
+                raise ValueError(
+                    f"FunASR timestamps must be finite at word index {index}."
+                )
+            if (
+                start < 0
+                or end < start
+                or start < previous_start
+                or end < previous_end
+            ):
+                raise ValueError(
+                    "Invalid or non-monotonic FunASR timestamp span "
+                    f"at word index {index}."
+                )
+            spans.append((start, end))
+            previous_start, previous_end = start, end
+        return spans
+
+    @staticmethod
+    def _is_decoration(text):
+        return all(
+            char.isspace()
+            or unicodedata.category(char)[0] in {"M", "P", "S", "Z"}
+            or char == "\u200d"
+            for char in text
+        )
+
+    def _project_words(self, text, words):
+        positions = []
+        cursor = 0
+        for index, word in enumerate(words):
+            if not isinstance(word, str) or not word:
+                raise ValueError(f"Invalid FunASR word at word index {index}.")
+            start = text.find(word, cursor)
+            if start < 0:
+                raise ValueError(
+                    f"Cannot map FunASR word index {index} into postprocessed text "
+                    f"(text length {len(text)}, word length {len(word)})."
+                )
+            if not self._is_decoration(text[cursor:start]):
+                raise ValueError(
+                    f"FunASR left unassigned text before word index {index}."
+                )
+            end = start + len(word)
+            positions.append((start, end))
+            cursor = end
+
+        if positions and not self._is_decoration(text[cursor:]):
+            raise ValueError(
+                f"FunASR left unassigned text after word index {len(words) - 1}."
+            )
+
+        boundaries = [0]
+        for previous, current in zip(positions, positions[1:]):
+            gap = text[previous[1] : current[0]]
+            trailing_whitespace = len(gap) - len(gap.rstrip())
+            boundaries.append(current[0] - trailing_whitespace)
+        boundaries.append(len(text))
+        pieces = [
+            text[boundaries[index] : boundaries[index + 1]]
+            for index in range(len(words))
+        ]
+        if "".join(pieces) != text:
+            raise ValueError(
+                "FunASR timestamped text reconstruction failed for "
+                f"text length {len(text)}."
+            )
+        return pieces
+
+    def ts_words(self, result):
+        item = self._result_item(result)
+        if item is None:
+            return []
+
+        required_fields = {"text", "words", "timestamp"}
+        missing_fields = sorted(required_fields.difference(item))
+        if missing_fields:
+            raise ValueError(
+                "FunASR result missing required field(s): "
+                + ", ".join(missing_fields)
+                + "."
+            )
+
+        raw_text = item["text"]
+        if not isinstance(raw_text, str):
+            raise ValueError("FunASR result text must be a string.")
+        text = self._postprocess(raw_text)
+        if not isinstance(text, str):
+            raise ValueError("FunASR postprocessed text must be a string.")
+
+        words = item["words"]
+        timestamps = item["timestamp"]
+        if not isinstance(words, (list, tuple)):
+            raise ValueError("FunASR result words must be a list.")
+        if not isinstance(timestamps, (list, tuple)):
+            raise ValueError("FunASR result timestamp must be a list.")
+        if not text and not words and not timestamps:
+            return []
+        if not words:
+            raise ValueError("FunASR returned text without timestamped words.")
+
+        spans = self._validated_spans(timestamps, len(words))
+        pieces = self._project_words(text, words)
+        match = _LANGUAGE_TAG.search(raw_text)
+        tagged_language = match.group("language") if match else None
+        if _REQUEST_LANGUAGE_KEY in item:
+            detected_language = item[_REQUEST_LANGUAGE_KEY] or tagged_language
+        else:
+            detected_language = self.original_language or tagged_language
+        tokens = [
+            ASRToken(start, end, piece, detected_language=detected_language)
+            for piece, (start, end) in zip(pieces, spans)
+        ]
+        if self.sep.join(token.text for token in tokens) != text:
+            raise ValueError(
+                "FunASR timestamped text reconstruction failed for "
+                f"text length {len(text)}."
+            )
+        return tokens
+
+    def segments_end_ts(self, result):
+        tokens = self.ts_words(result)
+        return [tokens[-1].end] if tokens else []
+
+    def use_vad(self):
+        """Keep WLK's VAC/VAD pipeline authoritative."""
+        return None
+
+
+class FunASROnlineASRProcessor(OnlineASRProcessor):
+    """Prevent SenseVoice's committed EOF batch from remaining pending."""
+
+    def finish(self):
+        remaining_tokens, final_processed_upto = super().finish()
+        self.transcript_buffer.buffer = []
+        return remaining_tokens, final_processed_upto

--- a/whisperlivekit/funasr_backend.py
+++ b/whisperlivekit/funasr_backend.py
@@ -34,6 +34,7 @@ def _load_funasr_dependencies():
 class FunASRASR:
     """Adapt SenseVoice's offline output to WLK's LocalAgreement contract."""
 
+    SAMPLING_RATE = 16000
     sep = ""
 
     def __init__(
@@ -229,6 +230,8 @@ class FunASRASR:
         if not isinstance(timestamps, (list, tuple)):
             raise ValueError("FunASR result timestamp must be a list.")
         if not text and not words and not timestamps:
+            return []
+        if not words and not timestamps and self._is_decoration(text):
             return []
         if not words:
             raise ValueError("FunASR returned text without timestamped words.")

--- a/whisperlivekit/local_agreement/whisper_online.py
+++ b/whisperlivekit/local_agreement/whisper_online.py
@@ -12,7 +12,7 @@ from .backends import FasterWhisperASR, MLXWhisper, OpenaiApiASR, WhisperASR
 logger = logging.getLogger(__name__)
 
 
-WHISPER_LANG_CODES = "af,am,ar,as,az,ba,be,bg,bn,bo,br,bs,ca,cs,cy,da,de,el,en,es,et,eu,fa,fi,fo,fr,gl,gu,ha,haw,he,hi,hr,ht,hu,hy,id,is,it,ja,jw,ka,kk,km,kn,ko,la,lb,ln,lo,lt,lv,mg,mi,mk,ml,mn,mr,ms,mt,my,ne,nl,nn,no,oc,pa,pl,ps,pt,ro,ru,sa,sd,si,sk,sl,sn,so,sq,sr,su,sv,sw,ta,te,tg,th,tk,tl,tr,tt,uk,ur,uz,vi,yi,yo,yue,zh".split(
+WHISPER_LANG_CODES = "af,am,ar,as,az,ba,be,bg,bn,bo,br,bs,ca,cs,cy,da,de,el,en,es,et,eu,fa,fi,fo,fr,gl,gu,ha,haw,he,hi,hr,ht,hu,hy,id,is,it,ja,jw,ka,kk,km,kn,ko,la,lb,ln,lo,lt,lv,mg,mi,mk,ml,mn,mr,ms,mt,my,ne,nl,nn,no,oc,pa,pl,ps,pt,ro,ru,sa,sd,si,sk,sl,sn,so,sq,sr,su,sv,sw,ta,te,tg,th,tk,tl,tr,tt,uk,ur,uz,vi,yi,yo,zh".split(
     ","
 )
 
@@ -81,8 +81,12 @@ def backend_factory(
             **_unused_kwargs,
         ):
     if backend == "funasr":
+        from whisperlivekit.config import FUNASR_LANGUAGES
         from whisperlivekit.funasr_backend import FunASRASR
 
+        if lan not in FUNASR_LANGUAGES:
+            supported = ", ".join(sorted(FUNASR_LANGUAGES))
+            raise ValueError(f"FunASR SenseVoiceSmall supports only: {supported}.")
         t = time.time()
         logger.info("Loading SenseVoiceSmall for language %s using FunASR...", lan)
         asr = FunASRASR(

--- a/whisperlivekit/local_agreement/whisper_online.py
+++ b/whisperlivekit/local_agreement/whisper_online.py
@@ -12,7 +12,7 @@ from .backends import FasterWhisperASR, MLXWhisper, OpenaiApiASR, WhisperASR
 logger = logging.getLogger(__name__)
 
 
-WHISPER_LANG_CODES = "af,am,ar,as,az,ba,be,bg,bn,bo,br,bs,ca,cs,cy,da,de,el,en,es,et,eu,fa,fi,fo,fr,gl,gu,ha,haw,he,hi,hr,ht,hu,hy,id,is,it,ja,jw,ka,kk,km,kn,ko,la,lb,ln,lo,lt,lv,mg,mi,mk,ml,mn,mr,ms,mt,my,ne,nl,nn,no,oc,pa,pl,ps,pt,ro,ru,sa,sd,si,sk,sl,sn,so,sq,sr,su,sv,sw,ta,te,tg,th,tk,tl,tr,tt,uk,ur,uz,vi,yi,yo,zh".split(
+WHISPER_LANG_CODES = "af,am,ar,as,az,ba,be,bg,bn,bo,br,bs,ca,cs,cy,da,de,el,en,es,et,eu,fa,fi,fo,fr,gl,gu,ha,haw,he,hi,hr,ht,hu,hy,id,is,it,ja,jw,ka,kk,km,kn,ko,la,lb,ln,lo,lt,lv,mg,mi,mk,ml,mn,mr,ms,mt,my,ne,nl,nn,no,oc,pa,pl,ps,pt,ro,ru,sa,sd,si,sk,sl,sn,so,sq,sr,su,sv,sw,ta,te,tg,th,tk,tl,tr,tt,uk,ur,uz,vi,yi,yo,yue,zh".split(
     ","
 )
 
@@ -80,6 +80,27 @@ def backend_factory(
             min_chunk_size=None,
             **_unused_kwargs,
         ):
+    if backend == "funasr":
+        from whisperlivekit.funasr_backend import FunASRASR
+
+        t = time.time()
+        logger.info("Loading SenseVoiceSmall for language %s using FunASR...", lan)
+        asr = FunASRASR(
+            lan=lan,
+            model_size=model_size,
+            cache_dir=model_cache_dir,
+            model_dir=model_dir,
+        )
+        tokenizer = create_tokenizer(lan) if buffer_trimming == "sentence" else None
+        warmup_asr(asr, warmup_file)
+        asr.confidence_validation = confidence_validation
+        asr.tokenizer = tokenizer
+        asr.buffer_trimming = buffer_trimming
+        asr.buffer_trimming_sec = buffer_trimming_sec
+        asr.backend_choice = "funasr"
+        logger.info("done. It took %.2f seconds.", time.time() - t)
+        return asr
+
     backend_choice = backend
     custom_reference = model_path or model_dir
     resolved_root = None

--- a/whisperlivekit/parse_args.py
+++ b/whisperlivekit/parse_args.py
@@ -206,8 +206,8 @@ def parse_args():
         "--backend",
         type=str,
         default="auto",
-        choices=["auto", "mlx-whisper", "faster-whisper", "whisper", "openai-api", "voxtral", "voxtral-mlx", "qwen3-vllm", "qwen3-vllm-metal", "qwen3-streaming"],
-        help="Select the ASR backend implementation. Use 'qwen3-vllm' for Qwen3-ASR through in-process vLLM with ForcedAligner on GPU. Use 'qwen3-vllm-metal' for Qwen3-ASR through vllm-metal in-process STT on Apple Silicon. Use 'qwen3-streaming' for Qwen3-ASR through plain HF Transformers with a bounded-recompute audio cache (CUDA/MPS/CPU, no vLLM; requires an explicit --language).",
+        choices=["auto", "mlx-whisper", "faster-whisper", "whisper", "openai-api", "funasr", "voxtral", "voxtral-mlx", "qwen3-vllm", "qwen3-vllm-metal", "qwen3-streaming"],
+        help="Select the ASR backend implementation. Use 'funasr' for SenseVoiceSmall through LocalAgreement (zh/yue/en/ja/ko or auto). Use 'qwen3-vllm' for Qwen3-ASR through in-process vLLM with ForcedAligner on GPU. Use 'qwen3-vllm-metal' for Qwen3-ASR through vllm-metal in-process STT on Apple Silicon. Use 'qwen3-streaming' for Qwen3-ASR through plain HF Transformers with a bounded-recompute audio cache (CUDA/MPS/CPU, no vLLM; requires an explicit --language).",
     )
     parser.add_argument(
         "--no-vac",

--- a/whisperlivekit/test_harness.py
+++ b/whisperlivekit/test_harness.py
@@ -71,7 +71,7 @@ def _parse_time(time_str: str) -> float:
 
 
 def load_audio_pcm(audio_path: str, sample_rate: int = SAMPLE_RATE) -> bytes:
-    """Load any audio file and convert to PCM s16le mono via ffmpeg."""
+    """Load any audio file and convert to PCM s16le mono."""
     cmd = [
         "ffmpeg", "-i", str(audio_path),
         "-f", "s16le", "-acodec", "pcm_s16le",
@@ -79,12 +79,79 @@ def load_audio_pcm(audio_path: str, sample_rate: int = SAMPLE_RATE) -> bytes:
         "-loglevel", "error",
         "pipe:1",
     ]
-    proc = subprocess.run(cmd, capture_output=True)
+    try:
+        proc = subprocess.run(cmd, capture_output=True)
+    except FileNotFoundError:
+        return _load_audio_pcm_without_ffmpeg(audio_path, sample_rate)
     if proc.returncode != 0:
         raise RuntimeError(f"ffmpeg conversion failed: {proc.stderr.decode().strip()}")
     if not proc.stdout:
         raise RuntimeError(f"ffmpeg produced no output for {audio_path}")
     return proc.stdout
+
+
+def _load_audio_pcm_without_ffmpeg(audio_path: str, sample_rate: int) -> bytes:
+    """Fallback audio loader for environments where ffmpeg is unavailable."""
+    errors = []
+    try:
+        import numpy as np
+        import soundfile as sf
+
+        waveform, source_rate = sf.read(str(audio_path), dtype="float32", always_2d=False)
+        waveform = _mono_audio(waveform, np)
+        if source_rate != sample_rate:
+            waveform = _resample_audio(waveform, source_rate, sample_rate, np)
+        return _float_audio_to_pcm(waveform, np)
+    except Exception as exc:
+        errors.append(exc)
+
+    try:
+        import librosa
+        import numpy as np
+
+        waveform, _ = librosa.load(str(audio_path), sr=sample_rate, mono=True)
+        return _float_audio_to_pcm(waveform, np)
+    except Exception as exc:
+        errors.append(exc)
+
+    try:
+        import torch
+        import torchaudio
+
+        waveform, source_rate = torchaudio.load(str(audio_path))
+    except Exception as exc:
+        errors.append(exc)
+        detail = "; ".join(str(error) for error in errors)
+        raise RuntimeError(f"fallback audio loading failed: {detail}") from exc
+    if waveform.ndim != 2 or waveform.shape[0] == 0:
+        raise RuntimeError(f"torchaudio produced invalid audio for {audio_path}")
+    if waveform.shape[0] > 1:
+        waveform = waveform.mean(dim=0, keepdim=True)
+    if source_rate != sample_rate:
+        waveform = torchaudio.functional.resample(waveform, source_rate, sample_rate)
+    pcm = (waveform.squeeze(0).clamp(-1.0, 1.0) * 32767.0).to(torch.int16)
+    return pcm.cpu().numpy().tobytes()
+
+
+def _mono_audio(waveform, np):
+    if waveform.ndim == 1:
+        return waveform
+    return waveform.mean(axis=1)
+
+
+def _resample_audio(waveform, source_rate: int, target_rate: int, np):
+    if len(waveform) == 0:
+        return waveform
+    duration = len(waveform) / source_rate
+    target_length = max(1, int(round(duration * target_rate)))
+    source_positions = np.linspace(0.0, duration, num=len(waveform), endpoint=False)
+    target_positions = np.linspace(0.0, duration, num=target_length, endpoint=False)
+    return np.interp(target_positions, source_positions, waveform).astype("float32")
+
+
+def _float_audio_to_pcm(waveform, np) -> bytes:
+    pcm = (np.clip(waveform, -1.0, 1.0) * 32767.0).astype("<i2")
+    return pcm.tobytes()
 
 
 # ---------------------------------------------------------------------------

--- a/whisperlivekit/test_harness.py
+++ b/whisperlivekit/test_harness.py
@@ -71,7 +71,7 @@ def _parse_time(time_str: str) -> float:
 
 
 def load_audio_pcm(audio_path: str, sample_rate: int = SAMPLE_RATE) -> bytes:
-    """Load any audio file and convert to PCM s16le mono."""
+    """Load any audio file and convert to PCM s16le mono via ffmpeg."""
     cmd = [
         "ffmpeg", "-i", str(audio_path),
         "-f", "s16le", "-acodec", "pcm_s16le",
@@ -79,79 +79,12 @@ def load_audio_pcm(audio_path: str, sample_rate: int = SAMPLE_RATE) -> bytes:
         "-loglevel", "error",
         "pipe:1",
     ]
-    try:
-        proc = subprocess.run(cmd, capture_output=True)
-    except FileNotFoundError:
-        return _load_audio_pcm_without_ffmpeg(audio_path, sample_rate)
+    proc = subprocess.run(cmd, capture_output=True)
     if proc.returncode != 0:
         raise RuntimeError(f"ffmpeg conversion failed: {proc.stderr.decode().strip()}")
     if not proc.stdout:
         raise RuntimeError(f"ffmpeg produced no output for {audio_path}")
     return proc.stdout
-
-
-def _load_audio_pcm_without_ffmpeg(audio_path: str, sample_rate: int) -> bytes:
-    """Fallback audio loader for environments where ffmpeg is unavailable."""
-    errors = []
-    try:
-        import numpy as np
-        import soundfile as sf
-
-        waveform, source_rate = sf.read(str(audio_path), dtype="float32", always_2d=False)
-        waveform = _mono_audio(waveform, np)
-        if source_rate != sample_rate:
-            waveform = _resample_audio(waveform, source_rate, sample_rate, np)
-        return _float_audio_to_pcm(waveform, np)
-    except Exception as exc:
-        errors.append(exc)
-
-    try:
-        import librosa
-        import numpy as np
-
-        waveform, _ = librosa.load(str(audio_path), sr=sample_rate, mono=True)
-        return _float_audio_to_pcm(waveform, np)
-    except Exception as exc:
-        errors.append(exc)
-
-    try:
-        import torch
-        import torchaudio
-
-        waveform, source_rate = torchaudio.load(str(audio_path))
-    except Exception as exc:
-        errors.append(exc)
-        detail = "; ".join(str(error) for error in errors)
-        raise RuntimeError(f"fallback audio loading failed: {detail}") from exc
-    if waveform.ndim != 2 or waveform.shape[0] == 0:
-        raise RuntimeError(f"torchaudio produced invalid audio for {audio_path}")
-    if waveform.shape[0] > 1:
-        waveform = waveform.mean(dim=0, keepdim=True)
-    if source_rate != sample_rate:
-        waveform = torchaudio.functional.resample(waveform, source_rate, sample_rate)
-    pcm = (waveform.squeeze(0).clamp(-1.0, 1.0) * 32767.0).to(torch.int16)
-    return pcm.cpu().numpy().tobytes()
-
-
-def _mono_audio(waveform, np):
-    if waveform.ndim == 1:
-        return waveform
-    return waveform.mean(axis=1)
-
-
-def _resample_audio(waveform, source_rate: int, target_rate: int, np):
-    if len(waveform) == 0:
-        return waveform
-    duration = len(waveform) / source_rate
-    target_length = max(1, int(round(duration * target_rate)))
-    source_positions = np.linspace(0.0, duration, num=len(waveform), endpoint=False)
-    target_positions = np.linspace(0.0, duration, num=target_length, endpoint=False)
-    return np.interp(target_positions, source_positions, waveform).astype("float32")
-
-
-def _float_audio_to_pcm(waveform, np) -> bytes:
-    pcm = (np.clip(waveform, -1.0, 1.0) * 32767.0).astype("<i2")
-    return pcm.tobytes()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add an optional FunASR backend for `iic/SenseVoiceSmall`
- route SenseVoiceSmall through WhisperLiveKit's existing LocalAgreement and VAC/VAD pipeline
- preserve rich postprocessed text with word timestamps and fail closed on malformed model output
- support `auto`, Mandarin, Cantonese, English, Japanese, and Korean with safe per-session language overrides
- document installation, model scope, language limits, and model licensing

## Why

Issue #366 proposed FunASR as an additional backend. This implements the maintainer-documented backend interface while keeping the first compatibility contract intentionally narrow: SenseVoiceSmall only, not arbitrary FunASR checkpoints.

The adapter disables remote model code and update checks, uses an isolated inference cache for every call, and leaves speech-boundary handling to WLK. The optional dependency is constrained to the tested FunASR 1.3.x API.

## Validation

- `34 passed` in focused config and result-adapter tests, with no mock model or mock pipeline tests
- `9 passed` against the real SenseVoiceSmall model and audio: five languages, exact timestamps/text, progressive stability, per-session language restoration, LocalAgreement, and `TestHarness`
- `96 passed, 9 skipped` with the repository's CI pytest command
- Ruff 0.15 passed on the CI checkout surface and all changed Python files
- `uv lock --check` passed
- wheel and sdist builds passed; wheel metadata contains `funasr~=1.3.14`
- public package import check passed

Fixes #366
