### PR TITLE
refactor: decouple audio processor into smaller modules

### DIFF
--- a/tests/test_backend_deep_bugs.py
+++ b/tests/test_backend_deep_bugs.py
@@ -634,10 +634,10 @@ def test_tokens_alignment_prunes_long_running_history():
 
 
 def test_audio_processor_prunes_persistent_state_tokens():
-    from whisperlivekit.audio_processor import AudioProcessor
+    from whisperlivekit.audio_processor import ResultAggregator
     from whisperlivekit.timed_objects import ASRToken, State
 
-    processor = object.__new__(AudioProcessor)
+    processor = object.__new__(ResultAggregator)
     processor.state = State()
     processor.tokens_alignment = SimpleNamespace(_retention_seconds=10.0)
     processor.state.end_buffer = 30.0
@@ -650,6 +650,7 @@ def test_audio_processor_prunes_persistent_state_tokens():
 
     assert processor.state.tokens[0].end >= 20.0
     assert processor.state.tokens[-1].text == " w29"
+
 
 def test_front_data_serializes_split_transcription_lags():
     from whisperlivekit.timed_objects import FrontData
@@ -700,20 +701,20 @@ def test_diff_protocol_preserves_split_transcription_lags():
 
 @pytest.mark.asyncio
 async def test_audio_processor_calculates_processing_and_policy_lag():
-    from whisperlivekit.audio_processor import AudioProcessor
+    from whisperlivekit.audio_processor import ResultAggregator
     from whisperlivekit.timed_objects import ASRToken, State
 
-    processor = object.__new__(AudioProcessor)
-    processor.lock = asyncio.Lock()
-    processor.state = State()
-    processor.sample_rate = 16000
-    processor.total_pcm_samples = 48000
-    processor.beg_loop = None
-    processor.args = SimpleNamespace(transcription=True)
-    processor.state.end_transcription_processed = 2.0
-    processor.state.tokens = [ASRToken(1.0, 1.4, "hello")]
+    sample_rate = 16000
+    total_pcm_samples = 48000
+    aggregator = object.__new__(ResultAggregator)
+    aggregator.state = State()
+    aggregator.chunker_ref = SimpleNamespace(get_audio_time=lambda: total_pcm_samples / sample_rate)
+    aggregator.beg_loop = None
+    aggregator.args = SimpleNamespace(transcription=True)
+    aggregator.state.end_transcription_processed = 2.0
+    aggregator.state.tokens = [ASRToken(1.0, 1.4, "hello")]
 
-    state = await processor.get_current_state()
+    state = aggregator.get_current_state()
 
     assert state.remaining_time_transcription_processing == 1.0
     assert state.remaining_time_transcription_policy == 0.6
@@ -721,20 +722,20 @@ async def test_audio_processor_calculates_processing_and_policy_lag():
 
 @pytest.mark.asyncio
 async def test_audio_processor_split_lags_are_zero_when_timestamps_are_aligned():
-    from whisperlivekit.audio_processor import AudioProcessor
+    from whisperlivekit.audio_processor import ResultAggregator
     from whisperlivekit.timed_objects import ASRToken, State
 
-    processor = object.__new__(AudioProcessor)
-    processor.lock = asyncio.Lock()
-    processor.state = State()
-    processor.sample_rate = 16000
-    processor.total_pcm_samples = 32000
-    processor.beg_loop = None
-    processor.args = SimpleNamespace(transcription=True)
-    processor.state.end_transcription_processed = 2.0
-    processor.state.tokens = [ASRToken(1.5, 2.0, "done")]
+    sample_rate = 16000
+    total_pcm_samples = 32000
+    aggregator = object.__new__(ResultAggregator)
+    aggregator.state = State()
+    aggregator.chunker_ref = SimpleNamespace(get_audio_time=lambda: total_pcm_samples / sample_rate)
+    aggregator.beg_loop = None
+    aggregator.args = SimpleNamespace(transcription=True)
+    aggregator.state.end_transcription_processed = 2.0
+    aggregator.state.tokens = [ASRToken(1.5, 2.0, "done")]
 
-    state = await processor.get_current_state()
+    state = aggregator.get_current_state()
 
     assert state.remaining_time_transcription_processing == 0.0
     assert state.remaining_time_transcription_policy == 0.0
@@ -742,7 +743,7 @@ async def test_audio_processor_split_lags_are_zero_when_timestamps_are_aligned()
 
 @pytest.mark.asyncio
 async def test_audio_processor_finish_commits_pending_buffer_when_backend_flush_is_empty():
-    from whisperlivekit.audio_processor import AudioProcessor
+    from whisperlivekit.audio_processor import ResultAggregator, TranscriptionWorker
     from whisperlivekit.metrics_collector import SessionMetrics
     from whisperlivekit.timed_objects import State, Transcript
 
@@ -753,26 +754,30 @@ async def test_audio_processor_finish_commits_pending_buffer_when_backend_flush_
         def get_buffer(self):
             return Transcript()
 
-    processor = object.__new__(AudioProcessor)
-    processor.transcription = EmptyFinishBackend()
-    processor.state = State()
-    processor.state.buffer_transcription = Transcript(
+    aggregator = object.__new__(ResultAggregator)
+    aggregator.state = State()
+    aggregator.state.buffer_transcription = Transcript(
         start=0.55,
         end=3.05,
         text="Concord returned to its place amidst the tents",
     )
-    processor.state.end_buffer = 3.5
-    processor.lock = asyncio.Lock()
-    processor.metrics = SessionMetrics()
-    processor.translation_queue = None
-    processor._prune_state_tokens = lambda: None
+    aggregator.state.end_buffer = 3.5
+    aggregator.tokens_alignment = None
 
-    await processor._finish_transcription()
+    worker = object.__new__(TranscriptionWorker)
+    worker.transcription = EmptyFinishBackend()
+    worker.aggregator = aggregator
+    worker.metrics = SessionMetrics()
+    worker.translation_queue = None
+    worker._pending_translation_tokens = []
+    worker.translate_on_complete = False
 
-    assert len(processor.state.new_tokens) == 1
-    assert processor.state.new_tokens[0].text == "Concord returned to its place amidst the tents"
-    assert processor.state.buffer_transcription.text == ""
-    assert processor.metrics.n_tokens_produced == 1
+    await worker._finish_transcription()
+
+    assert len(aggregator.state.new_tokens) == 1
+    assert aggregator.state.new_tokens[0].text == "Concord returned to its place amidst the tents"
+    assert aggregator.state.buffer_transcription.text == ""
+    assert worker.metrics.n_tokens_produced == 1
 
 
 def test_verbose_json_fallback_creates_segment_when_text_has_no_lines():
@@ -859,48 +864,50 @@ async def test_process_audio_non_pcm_closes_ffmpeg_stdin_without_sentinel():
     from whisperlivekit.audio_processor import AudioProcessor
 
     processor = object.__new__(AudioProcessor)
-    processor.beg_loop = 1.0
-    processor.is_stopping = False
     processor.is_pcm_input = False
-    processor.ffmpeg_manager = FakeFFmpegManager()
-    processor.transcription_queue = asyncio.Queue()
-    processor.pcm_buffer = bytearray()
+    processor.transcription_worker = None
+
+    processor.aggregator = SimpleNamespace(beg_loop=1.0, is_stopping=False)
+    processor.ingester = SimpleNamespace(ffmpeg_manager=FakeFFmpegManager())
+    processor.chunker = SimpleNamespace(transcription_queue=asyncio.Queue())
 
     await processor.process_audio(b"")
 
-    assert processor.is_stopping is True
-    assert processor.ffmpeg_manager.closed is True
-    assert processor.transcription_queue.empty()
+    assert processor.aggregator.is_stopping is True
+    assert processor.ingester.ffmpeg_manager.closed is True
+    assert processor.chunker.transcription_queue.empty()
 
 
 @pytest.mark.asyncio
 async def test_ffmpeg_reader_drains_stdout_after_stop_before_sentinel():
-    from whisperlivekit.audio_processor import SENTINEL, AudioProcessor
+    from whisperlivekit.audio_processor import AudioIngester, VADChunker, SENTINEL
 
-    processor = object.__new__(AudioProcessor)
-    processor.is_stopping = True
-    processor.ffmpeg_manager = FakeFFmpegManager([b"aaaa", None, b"bbbb", b""])
-    processor.pcm_buffer = bytearray()
-    processor.transcription_queue = asyncio.Queue()
-    processor.diarization_queue = None
-    processor.translation_queue = None
-    processor.diarization = None
-    processor.translation = None
-    processor.bytes_per_sample = 2
+    chunker = object.__new__(VADChunker)
+    chunker.pcm_buffer = bytearray()
+    chunker.transcription_queue = asyncio.Queue()
+    chunker.diarization_queue = None
+    chunker.translation_queue = None
+    chunker.bytes_per_sample = 2
+    chunker.sample_rate = 16000
+    chunker.current_silence = None
     seen = []
 
     async def fake_handle_pcm_data():
-        seen.append(bytes(processor.pcm_buffer))
-        processor.pcm_buffer.clear()
+        seen.append(bytes(chunker.pcm_buffer))
+        chunker.pcm_buffer.clear()
 
-    processor.handle_pcm_data = fake_handle_pcm_data
+    chunker.handle_pcm_data = fake_handle_pcm_data
 
-    await processor.ffmpeg_stdout_reader()
+    ingester = object.__new__(AudioIngester)
+    ingester.chunker = chunker
+    ingester.ffmpeg_manager = FakeFFmpegManager([b"aaaa", None, b"bbbb", b""])
+
+    await ingester.ffmpeg_stdout_reader()
 
     assert seen == [b"aaaa", b"bbbb"]
-    assert processor.ffmpeg_manager.stopped is True
-    assert await processor.transcription_queue.get() is SENTINEL
-    assert processor.transcription_queue.empty()
+    assert ingester.ffmpeg_manager.stopped is True
+    assert await chunker.transcription_queue.get() is SENTINEL
+    assert chunker.transcription_queue.empty()
 
 
 def test_concatenate_diar_segments_does_not_mutate_stored_segments():

--- a/tests/test_silent_backend_guard.py
+++ b/tests/test_silent_backend_guard.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from whisperlivekit.audio_processor import AudioProcessor
+from whisperlivekit.audio_processor import AudioProcessor, TranscriptionWorker
 from whisperlivekit.warmup import warmup_asr
 
 
@@ -86,16 +86,16 @@ def _watchdog_self():
     return SimpleNamespace(
         _any_asr_output=False,
         _silent_backend_warned=False,
-        _SILENT_BACKEND_WARN_SECONDS=AudioProcessor._SILENT_BACKEND_WARN_SECONDS,
+        _SILENT_BACKEND_WARN_SECONDS=TranscriptionWorker._SILENT_BACKEND_WARN_SECONDS,
     )
 
 
 def test_silent_backend_watchdog_fires_once(caplog):
     fake = _watchdog_self()
     with caplog.at_level(logging.ERROR, logger="whisperlivekit.audio_processor"):
-        AudioProcessor._warn_if_backend_silent(fake, 5.0)      # too early
-        AudioProcessor._warn_if_backend_silent(fake, 25.0)     # fires
-        AudioProcessor._warn_if_backend_silent(fake, 60.0)     # already warned
+        TranscriptionWorker._warn_if_backend_silent(fake, 5.0)      # too early
+        TranscriptionWorker._warn_if_backend_silent(fake, 25.0)     # fires
+        TranscriptionWorker._warn_if_backend_silent(fake, 60.0)     # already warned
     errors = [r for r in caplog.records if "produced no output" in r.message]
     assert len(errors) == 1
     assert fake._silent_backend_warned is True
@@ -105,5 +105,5 @@ def test_silent_backend_watchdog_respects_real_output(caplog):
     fake = _watchdog_self()
     fake._any_asr_output = True
     with caplog.at_level(logging.ERROR, logger="whisperlivekit.audio_processor"):
-        AudioProcessor._warn_if_backend_silent(fake, 120.0)
+        TranscriptionWorker._warn_if_backend_silent(fake, 120.0)
     assert not [r for r in caplog.records if "produced no output" in r.message]

--- a/tests/test_translation_alignatt.py
+++ b/tests/test_translation_alignatt.py
@@ -308,31 +308,29 @@ def test_factory_routes_alignatt_engine():
 def test_translation_processor_plumbing_with_fake_sidecar(sidecar):
     """Drive AudioProcessor.translation_processor as a bound coroutine over a
     real queue: tokens and tails in, Translation segments and buffer out."""
-    from types import SimpleNamespace
-
-    from whisperlivekit.audio_processor import SENTINEL, AudioProcessor
+    from whisperlivekit.audio_processor import SENTINEL, ResultAggregator, TranslationWorker
     from whisperlivekit.timed_objects import State
 
-    processor = SimpleNamespace(
-        translation_queue=asyncio.Queue(),
-        translation=make_client(sidecar),
-        state=State(),
-        lock=asyncio.Lock(),
+    aggregator = object.__new__(ResultAggregator)
+    aggregator.state = State()
+
+    worker = TranslationWorker(
+        translation_backend=make_client(sidecar),
+        in_queue=asyncio.Queue(),
+        aggregator=aggregator,
     )
 
     async def scenario():
-        task = asyncio.create_task(
-            AudioProcessor.translation_processor(processor)
-        )
-        await processor.translation_queue.put(token("Hello", 0.0, 0.4))
-        await processor.translation_queue.put(token("world.", 0.5, 0.9))
-        await processor.translation_queue.put(
+        task = asyncio.create_task(worker.run())
+        await worker.queue.put(token("Hello", 0.0, 0.4))
+        await worker.queue.put(token("world.", 0.5, 0.9))
+        await worker.queue.put(
             HypothesisTail(start=1.0, end=1.5, text="next words")
         )
         await asyncio.sleep(0.5)
-        await processor.translation_queue.put(SENTINEL)
+        await worker.queue.put(SENTINEL)
         await asyncio.wait_for(task, timeout=10)
 
     asyncio.run(scenario())
-    assert processor.state.new_translation, "no validated translation produced"
-    assert processor.state.new_translation[0].text == "HELLO WORLD. [F]"
+    assert aggregator.state.new_translation, "no validated translation produced"
+    assert aggregator.state.new_translation[0].text == "HELLO WORLD. [F]"

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -525,7 +525,8 @@ class TranscriptionWorker:
         # Silent-backend watchdog: flips once ASR produces anything
         self._any_asr_output: bool = False
         self._silent_backend_warned: bool = False
-        self._SILENT_BACKEND_WARN_SECONDS = 20.0
+
+    _SILENT_BACKEND_WARN_SECONDS = 20.0
 
     async def _queue_tokens_for_translation(self, tokens: List[ASRToken]) -> None:
         """Forward committed tokens to the translation queue.
@@ -558,11 +559,10 @@ class TranscriptionWorker:
             return
         self._silent_backend_warned = True
         logger.error(
-            "ASR backend produced no output after {:.0f} s of audio. The backend "
+            f"ASR backend produced no output after {audio_seconds:.0f} s of audio. The backend "
             "is likely failing on every chunk; check earlier warnings for the "
             "root cause (device mismatches, incompatible wheels, model load "
             "errors).",
-            audio_seconds,
         )
 
     async def _flush_pending_translation_tokens(self) -> None:

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import traceback
 from time import time
-from typing import Any, AsyncGenerator, List, Optional, Union
+from typing import Any, AsyncGenerator, Callable, List, Optional, Union
 
 import numpy as np
 
@@ -22,8 +22,9 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-SENTINEL = object() # unique sentinel object for end of stream marker
+SENTINEL = object()  # unique sentinel object for end of stream marker
 MIN_DURATION_REAL_SILENCE = 5
+
 
 async def get_all_from_queue(queue: asyncio.Queue) -> Union[object, Silence, np.ndarray, List[Any]]:
     items: List[Any] = []
@@ -48,46 +49,18 @@ async def get_all_from_queue(queue: asyncio.Queue) -> Union[object, Silence, np.
         queue.task_done()
     if isinstance(items[0], np.ndarray):
         return np.concatenate(items)
-    else: #translation
+    else:  # translation
         return items
 
-class AudioProcessor:
-    """
-    Processes audio streams for transcription and diarization.
-    Handles audio processing, state management, and result formatting.
-    """
 
-    def __init__(self, **kwargs: Any) -> None:
-        """Initialize the audio processor with configuration, models, and state."""
-        # Extract per-session options before passing to TranscriptionEngine
-        session_language = kwargs.pop('language', None)
-        # Output mode of the session: "full" resends the whole transcript on
-        # every update, so history must never be pruned away (issue #372);
-        # "diff" clients keep their own copy and allow bounded server memory.
-        session_mode = kwargs.pop('mode', 'full')
-        session_target_language = kwargs.pop('target_language', None)
+class ResultAggregator:
+    """Owns the shared state and strictly manages updates via synchronous callbacks to prevent race conditions."""
 
-        if 'transcription_engine' in kwargs and isinstance(kwargs['transcription_engine'], TranscriptionEngine):
-            models = kwargs['transcription_engine']
-        else:
-            models = TranscriptionEngine(**kwargs)
-
-        # Audio processing settings
-        self.args = models.args
-        self.sample_rate = 16000
-        self.channels = 1
-        chunk_seconds = self.args.vac_chunk_size if self.args.vac else self.args.min_chunk_size
-        self.samples_per_sec = int(self.sample_rate * chunk_seconds)
-        self.bytes_per_sample = 2
-        self.bytes_per_sec = self.samples_per_sec * self.bytes_per_sample
-        self.max_bytes_per_sec = 32000 * 5  # 5 seconds of audio at 32 kHz
-        self.is_pcm_input = self.args.pcm_input
-
-        # State management
-        self.is_stopping: bool = False
-        self.current_silence: Optional[Silence] = None
+    def __init__(self, args, metrics: SessionMetrics, session_mode: str = "full"):
+        self.args = args
+        self.metrics = metrics
+        self.session_mode = session_mode
         self.state: State = State()
-        self.lock: asyncio.Lock = asyncio.Lock()
         self.sep: str = " "  # Default separator
         self.last_response_content: FrontData = FrontData()
 
@@ -99,255 +72,58 @@ class AudioProcessor:
                 getattr(self.args, "retention_seconds", None), session_mode
             ),
         )
+        self.has_translation = False
         self.beg_loop: Optional[float] = None
+        self.ffmpeg_error: Optional[str] = None
+        self.is_stopping: bool = False
+        self.chunker_ref = None  # Reference to VADChunker to read current audio time/silence
 
-        # Models and processing
-        self.asr: Any = models.asr
-        self.vac: Optional[FixedVADIterator] = None
+    def update_transcription(self, new_tokens: List[ASRToken], buffer_transcript: Transcript, candidate_end_times: List[float], current_audio_processed_upto: Optional[float] = None):
+        """Synchronously updates transcription state. Replaces the old `async with self.lock` block."""
+        self.state.tokens.extend(new_tokens)
+        self.state.buffer_transcription = buffer_transcript
+        self.state.new_tokens.extend(new_tokens)
+        self.state.new_tokens_buffer = buffer_transcript
+        if candidate_end_times:
+            self.state.end_buffer = max(candidate_end_times)
+        self.update_transcription_time(new_tokens, current_audio_processed_upto)
+        self._prune_state_tokens()
 
-        if self.args.vac:
-            if models.vac_session is not None:
-                vac_model = OnnxWrapper(session=models.vac_session)
-                self.vac = FixedVADIterator(vac_model)
-            else:
-                self.vac = FixedVADIterator(load_jit_vad())
-        self.ffmpeg_manager: Optional[FFmpegManager] = None
-        self.ffmpeg_reader_task: Optional[asyncio.Task] = None
-        self._ffmpeg_error: Optional[str] = None
-
-        if not self.is_pcm_input:
-            self.ffmpeg_manager = FFmpegManager(
-                sample_rate=self.sample_rate,
-                channels=self.channels
+    def update_transcription_time(self, new_tokens: List[ASRToken], current_audio_processed_upto: Optional[float] = None):
+        if current_audio_processed_upto is not None:
+            self.state.end_transcription_processed = max(
+                self.state.end_transcription_processed, current_audio_processed_upto
             )
-            async def handle_ffmpeg_error(error_type: str):
-                logger.error(f"FFmpeg error: {error_type}")
-                self._ffmpeg_error = error_type
-            self.ffmpeg_manager.on_error_callback = handle_ffmpeg_error
-
-        self.transcription_queue: Optional[asyncio.Queue] = asyncio.Queue() if self.args.transcription else None
-        self.diarization_queue: Optional[asyncio.Queue] = asyncio.Queue() if self.args.diarization else None
-        self.translation_queue: Optional[asyncio.Queue] = asyncio.Queue() if self.args.target_language else None
-        self.pcm_buffer: bytearray = bytearray()
-        self.total_pcm_samples: int = 0
-        self.transcription_task: Optional[asyncio.Task] = None
-        self.diarization_task: Optional[asyncio.Task] = None
-        self.translation_task: Optional[asyncio.Task] = None
-        self.watchdog_task: Optional[asyncio.Task] = None
-        self.all_tasks_for_cleanup: List[asyncio.Task] = []
-        self.metrics: SessionMetrics = SessionMetrics()
-
-        self.transcription: Optional[Any] = None
-        self.translation: Optional[Any] = None
-        self.diarization: Optional[Any] = None
-
-        if self.args.transcription:
-            self.transcription = online_factory(self.args, models.asr, language=session_language)
-            self.sep = self.transcription.asr.sep
-        if self.args.diarization:
-            self.diarization = online_diarization_factory(self.args, models.diarization_model)
-        if models.translation_model:
-            if session_target_language and session_target_language != self.args.target_language:
-                from whisperlivekit.translation import session_translation_factory
-                self.translation = session_translation_factory(
-                    self.args, models.translation_model, session_target_language
-                )
-            else:
-                self.translation = online_translation_factory(self.args, models.translation_model)
-        elif session_target_language:
-            logger.warning(
-                "Session requested target_language=%r but the server was started "
-                "without translation (--target-language); ignoring.",
-                session_target_language,
+        if new_tokens:
+            self.state.end_transcription_committed = max(
+                self.state.end_transcription_committed, new_tokens[-1].end or 0.0
             )
 
-        # Translate-on-segment-complete (issue #264): when enabled, committed
-        # tokens are held back until their segment is finalized by punctuation
-        # (or a silence/end-of-stream boundary), so the translation output does
-        # not flicker while the partial text evolves.
-        self.translate_on_complete: bool = bool(getattr(self.args, "translate_on_complete", False))
-        self._pending_translation_tokens: List[ASRToken] = []
+    def update_new_token(self, token: Union[ASRToken, Silence]):
+        """Synchronously updates transcription state. Replaces the old `async with self.lock` block."""
+        self.state.new_tokens.append(token)
 
-        # Silent-backend watchdog: flips once the ASR has produced anything.
-        self._any_asr_output: bool = False
-        self._silent_backend_warned: bool = False
+    def update_buffer_transcription(self, buffer_transcript: Transcript):
+        """Synchronously updates transcription state. Replaces the old `async with self.lock` block."""
+        self.state.new_tokens_buffer = buffer_transcript
 
-    async def _queue_tokens_for_translation(self, tokens: List[ASRToken]) -> None:
-        """Forward committed tokens to the translation queue.
+    def append_diarization(self, diarization_segments, diar_end: float):
+        self.state.new_diarization.extend(diarization_segments)
+        self.state.end_attributed_speaker = max(self.state.end_attributed_speaker, diar_end)
 
-        With translate_on_complete, tokens are held back until a token
-        carrying punctuation closes the segment; the incomplete tail stays
-        pending and is not translated (issue #264).
-        """
-        if not self.translation_queue or not tokens:
-            return
-        if not self.translate_on_complete:
-            for token in tokens:
-                await self.translation_queue.put(token)
-            return
-        self._pending_translation_tokens.extend(tokens)
-        last_punctuation_idx = -1
-        for i, token in enumerate(self._pending_translation_tokens):
-            if token.has_punctuation():
-                last_punctuation_idx = i
-        if last_punctuation_idx >= 0:
-            for token in self._pending_translation_tokens[:last_punctuation_idx + 1]:
-                await self.translation_queue.put(token)
-            self._pending_translation_tokens = self._pending_translation_tokens[last_punctuation_idx + 1:]
+    def replace_diarization(self, diarization_segments, diar_end: float):
+        self.state.new_diarization = diarization_segments
+        self.state.end_attributed_speaker = max(self.state.end_attributed_speaker, diar_end)
 
-    _SILENT_BACKEND_WARN_SECONDS = 20.0
-
-    def _warn_if_backend_silent(self, audio_seconds: float) -> None:
-        """One-time loud error when the ASR consumed audio but never produced
-        a single token or buffer character.
-
-        Every real occurrence of this so far was a backend failing on every
-        chunk while its exceptions were only logged as warnings (torch 2.13
-        MLX device mismatch #383, CTranslate2 wheels with PTX newer than the
-        driver): the server looked healthy and sessions showed empty captions.
-        """
-        if self._silent_backend_warned or self._any_asr_output:
-            return
-        if audio_seconds < self._SILENT_BACKEND_WARN_SECONDS:
-            return
-        self._silent_backend_warned = True
-        logger.error(
-            "ASR backend produced no output after %.0f s of audio. The backend "
-            "is likely failing on every chunk; check earlier warnings for the "
-            "root cause (device mismatches, incompatible wheels, model load "
-            "errors).",
-            audio_seconds,
-        )
-
-    async def _flush_pending_translation_tokens(self) -> None:
-        """Release held-back tokens at a segment boundary (silence or end of stream)."""
-        if self.translation_queue and self._pending_translation_tokens:
-            for token in self._pending_translation_tokens:
-                await self.translation_queue.put(token)
-            self._pending_translation_tokens = []
-
-    async def _queue_hypothesis_tail_for_translation(self, buffer_transcript) -> None:
-        """Forward the unstable ASR tail to translation backends that opt in.
-
-        A streaming translator (AlignAtt) drafts ahead over the tail while
-        committing only against committed words; NLLB never sees it.
-        """
-        if not self.translation_queue or self.translation is None:
-            return
-        if not getattr(self.translation, "wants_hypothesis_tail", False):
-            return
-        text = (buffer_transcript.text or "").strip() if buffer_transcript else ""
-        if not text:
-            return
-        await self.translation_queue.put(HypothesisTail(
-            start=buffer_transcript.start,
-            end=buffer_transcript.end,
-            text=text,
-        ))
-
-    async def _push_silence_event(self) -> None:
-        if self.transcription_queue:
-            await self.transcription_queue.put(self.current_silence)
-        if self.args.diarization and self.diarization_queue:
-            await self.diarization_queue.put(self.current_silence)
-        if self.translation_queue:
-            await self._flush_pending_translation_tokens()
-            await self.translation_queue.put(self.current_silence)
-
-    async def _begin_silence(self, at_sample: Optional[int] = None) -> None:
-        if self.current_silence:
-            return
-        # Use audio stream time (sample-precise) for accurate silence duration
-        if at_sample is not None:
-            audio_t = at_sample / self.sample_rate
-        else:
-            audio_t = self.total_pcm_samples / self.sample_rate if self.sample_rate else 0.0
-        self.current_silence = Silence(
-            is_starting=True, start=audio_t
-        )
-        # Push a separate start-only event so _end_silence won't mutate it
-        start_event = Silence(is_starting=True, start=audio_t)
-        if self.transcription_queue:
-            await self.transcription_queue.put(start_event)
-        if self.args.diarization and self.diarization_queue:
-            await self.diarization_queue.put(start_event)
-        if self.translation_queue:
-            await self._flush_pending_translation_tokens()
-            await self.translation_queue.put(start_event)
-
-    async def _end_silence(self, at_sample: Optional[int] = None) -> None:
-        if not self.current_silence:
-            return
-        if at_sample is not None:
-            audio_t = at_sample / self.sample_rate
-        else:
-            audio_t = self.total_pcm_samples / self.sample_rate if self.sample_rate else 0.0
-        self.current_silence.end = audio_t
-        self.current_silence.is_starting = False
-        self.current_silence.has_ended = True
-        self.current_silence.compute_duration()
-        self.metrics.n_silence_events += 1
-        if self.current_silence.duration is not None:
-            self.metrics.total_silence_duration_s += self.current_silence.duration
-        if self.current_silence.duration and self.current_silence.duration > MIN_DURATION_REAL_SILENCE:
-            self.state.new_tokens.append(self.current_silence)
-        # Push the completed silence as the end event (separate from the start event)
-        await self._push_silence_event()
-        self.current_silence = None
-
-    async def _enqueue_active_audio(self, pcm_chunk: np.ndarray) -> None:
-        if pcm_chunk is None or pcm_chunk.size == 0:
-            return
-        if self.transcription_queue:
-            await self.transcription_queue.put(pcm_chunk.copy())
-        if self.args.diarization and self.diarization_queue:
-            await self.diarization_queue.put(pcm_chunk.copy())
-
-    def convert_pcm_to_float(self, pcm_buffer: Union[bytes, bytearray]) -> np.ndarray:
-        """Convert PCM buffer in s16le format to normalized NumPy array."""
-        return np.frombuffer(pcm_buffer, dtype=np.int16).astype(np.float32) / 32768.0
+    def update_translation(self, new_translation, new_translation_buffer):
+        self.state.new_translation.append(new_translation)
+        self.state.new_translation_buffer = new_translation_buffer
 
     def _latest_committed_transcription_end(self) -> float:
         latest_end = self.state.end_transcription_committed
         if self.state.tokens:
             latest_end = max(latest_end, self.state.tokens[-1].end or 0.0)
         return latest_end
-
-    async def get_current_state(self) -> State:
-        """Get current state."""
-        async with self.lock:
-            current_time = time()
-
-            remaining_transcription = 0
-            if self.state.end_buffer > 0:
-                remaining_transcription = max(0, round(current_time - self.beg_loop - self.state.end_buffer, 1))
-
-            remaining_diarization = 0
-            if self.state.tokens:
-                latest_end = max(self.state.end_buffer, self.state.tokens[-1].end if self.state.tokens else 0)
-                remaining_diarization = max(0, round(latest_end - self.state.end_attributed_speaker, 1))
-
-            self.state.remaining_time_transcription = remaining_transcription
-            self.state.remaining_time_diarization = remaining_diarization
-
-            if getattr(getattr(self, "args", None), "transcription", True):
-                audio_received_end = self.total_pcm_samples / self.sample_rate if self.sample_rate else 0.0
-                processed_end = max(0.0, self.state.end_transcription_processed)
-                committed_end = self._latest_committed_transcription_end()
-                self.state.end_transcription_committed = committed_end
-                self.state.remaining_time_transcription_processing = max(
-                    0.0,
-                    round(audio_received_end - processed_end, 1),
-                )
-                self.state.remaining_time_transcription_policy = max(
-                    0.0,
-                    round(processed_end - committed_end, 1),
-                )
-            else:
-                self.state.remaining_time_transcription_processing = 0.0
-                self.state.remaining_time_transcription_policy = 0.0
-
-            return self.state
 
     def _prune_state_tokens(self) -> None:
         """Bound persistent token history while keeping recent timing context."""
@@ -368,363 +144,67 @@ class AudioProcessor:
 
         self.state.tokens = self.state.tokens[-1:]
 
-    async def ffmpeg_stdout_reader(self) -> None:
-        """Read audio data from FFmpeg stdout and process it into the PCM pipeline."""
-        beg = time()
-        cancelled = False
+    def get_current_state(self) -> State:
+        """Get current state."""
+
+        current_time = time()
+
+        remaining_transcription = 0
+        if self.state.end_buffer > 0:
+            remaining_transcription = max(0, round(current_time - self.beg_loop - self.state.end_buffer, 1))
+
+        remaining_diarization = 0
+        if self.state.tokens:
+            latest_end = max(self.state.end_buffer, self.state.tokens[-1].end if self.state.tokens else 0)
+            remaining_diarization = max(0, round(latest_end - self.state.end_attributed_speaker, 1))
+
+        self.state.remaining_time_transcription = remaining_transcription
+        self.state.remaining_time_diarization = remaining_diarization
+
+        if getattr(getattr(self, "args", None), "transcription", True):
+            audio_received_end = self.chunker_ref.get_audio_time() if self.chunker_ref else 0.0
+            processed_end = max(0.0, self.state.end_transcription_processed)
+            committed_end = self._latest_committed_transcription_end()
+            self.state.end_transcription_committed = committed_end
+            self.state.remaining_time_transcription_processing = max(
+                0.0,
+                round(audio_received_end - processed_end, 1),
+            )
+            self.state.remaining_time_transcription_policy = max(
+                0.0,
+                round(processed_end - committed_end, 1),
+            )
+        else:
+            self.state.remaining_time_transcription_processing = 0.0
+            self.state.remaining_time_transcription_policy = 0.0
+
+        return self.state
+
+    async def format_results(self, tasks_done_callback: Callable[[], bool]) -> AsyncGenerator[FrontData, None]:
+        """Format processing results for output. Replaces `AudioProcessor.results_formatter`."""
         while True:
             try:
-                state = await self.ffmpeg_manager.get_state() if self.ffmpeg_manager else FFmpegState.STOPPED
-                if state == FFmpegState.FAILED:
-                    logger.error("FFmpeg is in FAILED state, cannot read data")
-                    break
-                elif state == FFmpegState.STOPPED:
-                    logger.info("FFmpeg is stopped")
-                    break
-                elif state != FFmpegState.RUNNING:
-                    await asyncio.sleep(0.1)
-                    continue
-
-                current_time = time()
-                elapsed_time = max(0.0, current_time - beg)
-                buffer_size = max(int(32000 * elapsed_time), 4096)  # dynamic read
-                beg = current_time
-
-                chunk = await self.ffmpeg_manager.read_data(buffer_size)
-                if chunk is None:
-                    await asyncio.sleep(0.05)
-                    continue
-                if chunk == b"":
-                    logger.info("FFmpeg stdout reached EOF.")
-                    break
-
-                self.pcm_buffer.extend(chunk)
-                await self.handle_pcm_data()
-
-            except asyncio.CancelledError:
-                logger.info("ffmpeg_stdout_reader cancelled.")
-                cancelled = True
-                break
-            except Exception as e:
-                logger.warning(f"Exception in ffmpeg_stdout_reader: {e}")
-                logger.debug(f"Traceback: {traceback.format_exc()}")
-                await asyncio.sleep(0.2)
-
-        if cancelled:
-            return
-
-        await self._flush_remaining_pcm()
-        if self.ffmpeg_manager:
-            await self.ffmpeg_manager.stop()
-
-        logger.info("FFmpeg stdout processing finished. Signaling downstream processors if needed.")
-        await self._signal_input_complete()
-
-    async def _signal_input_complete(self) -> None:
-        """Signal end-of-input to the first active processing queue."""
-        if self.transcription_queue:
-            await self.transcription_queue.put(SENTINEL)
-            return
-        if self.diarization_queue:
-            await self.diarization_queue.put(SENTINEL)
-        if self.translation_queue:
-            await self.translation_queue.put(SENTINEL)
-
-    async def _finish_transcription(self) -> None:
-        """Call finish() on the online processor to flush remaining tokens."""
-        if not self.transcription:
-            return
-        try:
-            if hasattr(self.transcription, 'finish'):
-                final_tokens, end_time = await asyncio.to_thread(self.transcription.finish)
-            else:
-                # SimulStreamingOnlineProcessor uses start_silence() → process_iter(is_last=True)
-                final_tokens, end_time = await asyncio.to_thread(self.transcription.start_silence)
-
-            final_tokens = final_tokens or []
-            _buffer_transcript = self.transcription.get_buffer()
-            if not final_tokens and self.state.buffer_transcription and self.state.buffer_transcription.text:
-                pending = self.state.buffer_transcription
-                text = pending.text.strip()
-                if text:
-                    start = pending.start if pending.start is not None else self.state.end_buffer
-                    end = pending.end if pending.end is not None else end_time
-                    if end is None or end < start:
-                        end = start
-                    final_tokens = [
-                        ASRToken(
-                            start=start,
-                            end=end,
-                            text=text,
-                            detected_language=pending.detected_language,
-                        )
-                    ]
-                    _buffer_transcript = Transcript()
-
-            final_committed_end = final_tokens[-1].end if final_tokens else None
-            async with self.lock:
-                self.state.end_transcription_processed = max(
-                    self.state.end_transcription_processed,
-                    end_time,
-                )
-                if final_committed_end is not None:
-                    self.state.end_transcription_committed = max(
-                        self.state.end_transcription_committed,
-                        final_committed_end,
-                    )
-            if final_tokens:
-                logger.info(f"Finish flushed {len(final_tokens)} tokens")
-                self.metrics.n_tokens_produced += len(final_tokens)
-                async with self.lock:
-                    self.state.tokens.extend(final_tokens)
-                    self.state.buffer_transcription = _buffer_transcript
-                    self.state.end_buffer = max(self.state.end_buffer, end_time)
-                    self.state.new_tokens.extend(final_tokens)
-                    self.state.new_tokens_buffer = _buffer_transcript
-                    self._prune_state_tokens()
-                await self._queue_tokens_for_translation(final_tokens)
-            # End of stream finalizes the last segment even without punctuation
-            await self._flush_pending_translation_tokens()
-        except Exception as e:
-            logger.warning(f"Error finishing transcription: {e}")
-            logger.debug(f"Traceback: {traceback.format_exc()}")
-
-    async def transcription_processor(self) -> None:
-        """Process audio chunks for transcription."""
-        cumulative_pcm_duration_stream_time = 0.0
-
-        while True:
-            try:
-                # Use a timeout so we periodically wake up and refresh the
-                # buffer state.  Streaming backends (e.g. voxtral) may
-                # produce text tokens asynchronously; without a periodic
-                # drain, those tokens would sit unread until the next audio
-                # chunk arrives — causing the frontend to show nothing.
-                try:
-                    item = await asyncio.wait_for(
-                        get_all_from_queue(self.transcription_queue),
-                        timeout=0.5,
-                    )
-                except asyncio.TimeoutError:
-                    # No new audio — just refresh buffer for streaming backends
-                    _buffer_transcript = self.transcription.get_buffer()
-                    async with self.lock:
-                        self.state.buffer_transcription = _buffer_transcript
-                    continue
-
-                if item is SENTINEL:
-                    logger.debug("Transcription processor received sentinel. Finishing.")
-                    await self._finish_transcription()
-                    break
-
-                asr_internal_buffer_duration_s = len(getattr(self.transcription, 'audio_buffer', [])) / self.transcription.SAMPLING_RATE
-                transcription_lag_s = max(0.0, time() - self.beg_loop - self.state.end_buffer)
-                asr_processing_logs = f"internal_buffer={asr_internal_buffer_duration_s:.2f}s | lag={transcription_lag_s:.2f}s |"
-                stream_time_end_of_current_pcm = cumulative_pcm_duration_stream_time
-                new_tokens = []
-                current_audio_processed_upto = self.state.end_buffer
-
-                if isinstance(item, Silence):
-                    if item.is_starting:
-                        new_tokens, current_audio_processed_upto = await asyncio.to_thread(
-                            self.transcription.start_silence
-                        )
-                        asr_processing_logs += " + Silence starting"
-                    if item.has_ended:
-                        asr_processing_logs += f" + Silence of = {item.duration:.2f}s"
-                        cumulative_pcm_duration_stream_time += item.duration
-                        current_audio_processed_upto = cumulative_pcm_duration_stream_time
-                        self.transcription.end_silence(item.duration, self.state.tokens[-1].end if self.state.tokens else 0)
-                    if self.state.tokens:
-                        asr_processing_logs += f" | last_end = {self.state.tokens[-1].end} |"
-                    logger.info(asr_processing_logs)
-                    new_tokens = new_tokens or []
-                    current_audio_processed_upto = max(current_audio_processed_upto, stream_time_end_of_current_pcm)
-                elif isinstance(item, ChangeSpeaker):
-                    self.transcription.new_speaker(item)
-                    continue
-                elif isinstance(item, np.ndarray):
-                    pcm_array = item
-                    logger.info(asr_processing_logs)
-                    cumulative_pcm_duration_stream_time += len(pcm_array) / self.sample_rate
-                    stream_time_end_of_current_pcm = cumulative_pcm_duration_stream_time
-                    self.transcription.insert_audio_chunk(pcm_array, stream_time_end_of_current_pcm)
-                    _t0 = time()
-                    new_tokens, current_audio_processed_upto = await asyncio.to_thread(self.transcription.process_iter)
-                    _dur = time() - _t0
-                    self.metrics.transcription_durations.append(_dur)
-                    self.metrics.n_transcription_calls += 1
-                    new_tokens = new_tokens or []
-                    self.metrics.n_tokens_produced += len(new_tokens)
-
-                _buffer_transcript = self.transcription.get_buffer()
-                buffer_text = _buffer_transcript.text
-
-                if new_tokens:
-                    validated_text = self.sep.join([t.text for t in new_tokens])
-                    if buffer_text.startswith(validated_text):
-                        _buffer_transcript.text = buffer_text[len(validated_text):].lstrip()
-
-                candidate_end_times = [self.state.end_buffer]
-
-                if new_tokens:
-                    candidate_end_times.append(new_tokens[-1].end)
-
-                if _buffer_transcript.end is not None:
-                    candidate_end_times.append(_buffer_transcript.end)
-
-                candidate_end_times.append(current_audio_processed_upto)
-
-                async with self.lock:
-                    self.state.tokens.extend(new_tokens)
-                    self.state.buffer_transcription = _buffer_transcript
-                    self.state.end_buffer = max(candidate_end_times)
-                    self.state.end_transcription_processed = max(
-                        self.state.end_transcription_processed,
-                        current_audio_processed_upto,
-                    )
-                    if new_tokens:
-                        self.state.end_transcription_committed = max(
-                            self.state.end_transcription_committed,
-                            new_tokens[-1].end or 0.0,
-                        )
-                    self.state.new_tokens.extend(new_tokens)
-                    self.state.new_tokens_buffer = _buffer_transcript
-                    self._prune_state_tokens()
-
-                if new_tokens or buffer_text.strip():
-                    self._any_asr_output = True
-                else:
-                    self._warn_if_backend_silent(cumulative_pcm_duration_stream_time)
-
-                await self._queue_tokens_for_translation(new_tokens)
-                await self._queue_hypothesis_tail_for_translation(_buffer_transcript)
-            except Exception as e:
-                logger.warning(f"Exception in transcription_processor: {e}")
-                logger.warning(f"Traceback: {traceback.format_exc()}")
-                if 'pcm_array' in locals() and pcm_array is not SENTINEL : # Check if pcm_array was assigned from queue
-                    self.transcription_queue.task_done()
-
-        if self.is_stopping:
-            logger.info("Transcription processor finishing due to stopping flag.")
-            if self.diarization_queue:
-                await self.diarization_queue.put(SENTINEL)
-            if self.translation_queue:
-                await self.translation_queue.put(SENTINEL)
-
-        logger.info("Transcription processor task finished.")
-
-
-    async def _update_diarization_state(self, diarization_segments) -> None:
-        """Push new diarization segments into the shared state."""
-        if not diarization_segments:
-            return
-        diar_end = max(getattr(s, "end", 0.0) for s in diarization_segments)
-        async with self.lock:
-            self.state.new_diarization.extend(diarization_segments)
-            self.state.end_attributed_speaker = max(self.state.end_attributed_speaker, diar_end)
-
-    async def _drain_diarization_buffer(self) -> None:
-        """Process all remaining audio in the diarization buffer.
-
-        Sortformer-style backends accumulate audio in an internal buffer and
-        process one chunk per ``diarize()`` call, returning ``[]`` when the
-        buffer is too short.  This helper loops until the buffer is fully
-        consumed.
-        """
-        while True:
-            diarization_segments = await self.diarization.diarize()
-            if not diarization_segments:
-                break
-            await self._update_diarization_state(diarization_segments)
-
-    async def diarization_processor(self) -> None:
-        has_buffer = hasattr(self.diarization, 'buffer_audio')
-        while True:
-            try:
-                item = await get_all_from_queue(self.diarization_queue)
-                if item is SENTINEL:
-                    break
-                elif isinstance(item, Silence):
-                    if item.has_ended:
-                        self.diarization.insert_silence(item.duration)
-                    continue
-                self.diarization.insert_audio_chunk(item)
-                if has_buffer:
-                    await self._drain_diarization_buffer()
-                else:
-                    # Cumulative backends (e.g. Diart): replace, not extend
-                    diarization_segments = await self.diarization.diarize()
-                    diar_end = 0.0
-                    if diarization_segments:
-                        diar_end = max(getattr(s, "end", 0.0) for s in diarization_segments)
-                    async with self.lock:
-                        self.state.new_diarization = diarization_segments
-                        self.state.end_attributed_speaker = max(self.state.end_attributed_speaker, diar_end)
-            except Exception as e:
-                logger.warning(f"Exception in diarization_processor: {e}")
-                logger.warning(f"Traceback: {traceback.format_exc()}")
-        # Drain any remaining audio in the buffer before exiting
-        if has_buffer:
-            try:
-                await self._drain_diarization_buffer()
-            except Exception as e:
-                logger.warning(f"Exception draining diarization buffer: {e}")
-        logger.info("Diarization processor task finished.")
-
-    async def translation_processor(self) -> None:
-        # the idea is to ignore diarization for the moment. We use only transcription tokens.
-        # And the speaker is attributed given the segments used for the translation
-        # in the future we want to have different languages for each speaker etc, so it will be more complex.
-        while True:
-            try:
-                item = await get_all_from_queue(self.translation_queue)
-                if item is SENTINEL:
-                    logger.debug("Translation processor received sentinel. Finishing.")
-                    break
-
-                new_translation = None
-                new_translation_buffer = None
-
-                if isinstance(item, Silence):
-                    if item.is_starting:
-                        new_translation, new_translation_buffer = self.translation.validate_buffer_and_reset()
-                    if item.has_ended:
-                        self.translation.insert_silence(item.duration)
-                        continue
-                elif isinstance(item, ChangeSpeaker):
-                    new_translation, new_translation_buffer = self.translation.validate_buffer_and_reset()
-                else:
-                    self.translation.insert_tokens(item)
-                    new_translation, new_translation_buffer = await asyncio.to_thread(self.translation.process)
-
-                if new_translation is not None:
-                    async with self.lock:
-                        self.state.new_translation.append(new_translation)
-                        self.state.new_translation_buffer = new_translation_buffer
-            except Exception as e:
-                logger.warning(f"Exception in translation_processor: {e}")
-                logger.warning(f"Traceback: {traceback.format_exc()}")
-        logger.info("Translation processor task finished.")
-
-    async def results_formatter(self) -> AsyncGenerator[FrontData, None]:
-        """Format processing results for output."""
-        while True:
-            try:
-                if self._ffmpeg_error:
-                    yield FrontData(status="error", error=f"FFmpeg error: {self._ffmpeg_error}")
-                    self._ffmpeg_error = None
+                if self.ffmpeg_error:
+                    yield FrontData(status="error", error=f"FFmpeg error: {self.ffmpeg_error}")
+                    self.ffmpeg_error = None
                     await asyncio.sleep(1)
                     continue
 
                 self.tokens_alignment.update()
+
+                audio_time = None
+                current_silence = None
+                if self.chunker_ref:
+                    audio_time = self.chunker_ref.get_audio_time()
+                    current_silence = self.chunker_ref.current_silence
+
                 lines, buffer_diarization_text, buffer_translation_text = self.tokens_alignment.get_lines(
                     diarization=self.args.diarization,
-                    translation=bool(self.translation),
-                    current_silence=self.current_silence,
-                    audio_time=self.total_pcm_samples / self.sample_rate if self.sample_rate else None,
+                    translation=self.has_translation,
+                    current_silence=current_silence,
+                    audio_time=audio_time,
                 )
-                state = await self.get_current_state()
+                state = self.get_current_state()
 
                 buffer_transcription_text = state.buffer_transcription.text if state.buffer_transcription else ''
 
@@ -750,7 +230,7 @@ class AudioProcessor:
                     yield response
                     self.last_response_content = response
 
-                if self.is_stopping and self._processing_tasks_done():
+                if self.is_stopping and tasks_done_callback():
                     logger.info("Results formatter: All upstream processors are done and in stopping state. Terminating.")
                     return
 
@@ -760,155 +240,97 @@ class AudioProcessor:
                 logger.warning(f"Exception in results_formatter. Traceback: {traceback.format_exc()}")
                 await asyncio.sleep(0.5)
 
-    async def create_tasks(self) -> AsyncGenerator[FrontData, None]:
-        """Create and start processing tasks."""
-        self.all_tasks_for_cleanup = []
-        processing_tasks_for_watchdog: List[asyncio.Task] = []
 
-        # If using FFmpeg (non-PCM input), start it and spawn stdout reader
-        if not self.is_pcm_input:
-            success = await self.ffmpeg_manager.start()
-            if not success:
-                logger.error("Failed to start FFmpeg manager")
-                async def error_generator() -> AsyncGenerator[FrontData, None]:
-                    yield FrontData(
-                        status="error",
-                        error="FFmpeg failed to start. Please check that FFmpeg is installed."
-                    )
-                return error_generator()
-            self.ffmpeg_reader_task = asyncio.create_task(self.ffmpeg_stdout_reader())
-            self.all_tasks_for_cleanup.append(self.ffmpeg_reader_task)
-            processing_tasks_for_watchdog.append(self.ffmpeg_reader_task)
+class VADChunker:
+    """Handles silence calculation and chunking PCM into distinct VAD events."""
 
-        if self.transcription:
-            self.transcription_task = asyncio.create_task(self.transcription_processor())
-            self.all_tasks_for_cleanup.append(self.transcription_task)
-            processing_tasks_for_watchdog.append(self.transcription_task)
+    def __init__(self, args, vac_session, metrics: SessionMetrics):
+        self.args = args
+        self.metrics = metrics
+        self.sample_rate = 16000
+        chunk_seconds = self.args.vac_chunk_size if self.args.vac else self.args.min_chunk_size
+        self.bytes_per_sample = 2
+        self.bytes_per_sec = int(self.sample_rate * chunk_seconds) * self.bytes_per_sample
+        self.max_bytes_per_sec = 32000 * 5  # 5 seconds of audio at 32 kHz
 
-        if self.diarization:
-            self.diarization_task = asyncio.create_task(self.diarization_processor())
-            self.all_tasks_for_cleanup.append(self.diarization_task)
-            processing_tasks_for_watchdog.append(self.diarization_task)
+        self.transcription_queue: Optional[asyncio.Queue] = None
+        self.diarization_queue: Optional[asyncio.Queue] = None
+        self.translation_queue: Optional[asyncio.Queue] = None
 
-        if self.translation:
-            self.translation_task = asyncio.create_task(self.translation_processor())
-            self.all_tasks_for_cleanup.append(self.translation_task)
-            processing_tasks_for_watchdog.append(self.translation_task)
+        self.pcm_buffer: bytearray = bytearray()
+        self.total_pcm_samples: int = 0
+        self.current_silence: Optional[Silence] = None
 
-        # Monitor overall system health
-        self.watchdog_task = asyncio.create_task(self.watchdog(processing_tasks_for_watchdog))
-        self.all_tasks_for_cleanup.append(self.watchdog_task)
+        self.aggregator: ResultAggregator = None
 
-        return self.results_formatter()
+        self.vac: Optional[FixedVADIterator] = None
+        if self.args.vac:
+            if vac_session is not None:
+                vac_model = OnnxWrapper(session=vac_session)
+                self.vac = FixedVADIterator(vac_model)
+            else:
+                self.vac = FixedVADIterator(load_jit_vad())
 
-    async def watchdog(self, tasks_to_monitor: List[asyncio.Task]) -> None:
-        """Monitors the health of critical processing tasks."""
-        tasks_remaining: List[asyncio.Task] = [task for task in tasks_to_monitor if task]
-        while True:
-            try:
-                if not tasks_remaining:
-                    logger.info("Watchdog task finishing: all monitored tasks completed.")
-                    return
+    def get_audio_time(self) -> float:
+        return self.total_pcm_samples / self.sample_rate
 
-                await asyncio.sleep(10)
+    @staticmethod
+    def convert_pcm_to_float(pcm_buffer: Union[bytes, bytearray]) -> np.ndarray:
+        return np.frombuffer(pcm_buffer, dtype=np.int16).astype(np.float32) / 32768.0
 
-                for i, task in enumerate(list(tasks_remaining)):
-                    if task.done():
-                        exc = task.exception()
-                        task_name = task.get_name() if hasattr(task, 'get_name') else f"Monitored Task {i}"
-                        if exc:
-                            logger.error(f"{task_name} unexpectedly completed with exception: {exc}")
-                        else:
-                            logger.info(f"{task_name} completed normally.")
-                        tasks_remaining.remove(task)
+    async def _push_silence_event(self) -> None:
+        if self.transcription_queue:
+            await self.transcription_queue.put(self.current_silence)
+        if self.diarization_queue:
+            await self.diarization_queue.put(self.current_silence)
 
-            except asyncio.CancelledError:
-                logger.info("Watchdog task cancelled.")
-                break
-            except Exception as e:
-                logger.error(f"Error in watchdog task: {e}", exc_info=True)
-
-    async def cleanup(self) -> None:
-        """Clean up resources when processing is complete."""
-        logger.info("Starting cleanup of AudioProcessor resources.")
-        self.is_stopping = True
-        for task in self.all_tasks_for_cleanup:
-            if task and not task.done():
-                task.cancel()
-
-        created_tasks = [t for t in self.all_tasks_for_cleanup if t]
-        if created_tasks:
-            await asyncio.gather(*created_tasks, return_exceptions=True)
-        logger.info("All processing tasks cancelled or finished.")
-
-        if not self.is_pcm_input and self.ffmpeg_manager:
-            try:
-                await self.ffmpeg_manager.stop()
-                logger.info("FFmpeg manager stopped.")
-            except Exception as e:
-                logger.warning(f"Error stopping FFmpeg manager: {e}")
-        if self.diarization:
-            self.diarization.close()
-
-        # Finalize session metrics
-        self.metrics.total_audio_duration_s = self.total_pcm_samples / self.sample_rate
-        self.metrics.log_summary()
-        logger.info("AudioProcessor cleanup complete.")
-
-    def _processing_tasks_done(self) -> bool:
-        """Return True when all active processing tasks have completed."""
-        tasks_to_check = [
-            self.transcription_task,
-            self.diarization_task,
-            self.translation_task,
-            self.ffmpeg_reader_task,
-        ]
-        return all(task.done() for task in tasks_to_check if task)
-
-
-    async def process_audio(self, message: Optional[bytes]) -> None:
-        """Process incoming audio data."""
-
-        if not self.beg_loop:
-            self.beg_loop = time()
-            self.metrics.session_start = self.beg_loop
-            self.current_silence = Silence(start=0.0, is_starting=True)
-            self.tokens_alignment.beg_loop = self.beg_loop
-
-        if not message:
-            logger.info("Empty audio message received, initiating stop sequence.")
-            self.is_stopping = True
-
-            # Flush any remaining PCM data before signaling end-of-stream
-            if self.is_pcm_input:
-                if self.pcm_buffer:
-                    await self._flush_remaining_pcm()
-                await self._signal_input_complete()
-            elif self.ffmpeg_manager:
-                await self.ffmpeg_manager.close_stdin()
-
+    async def _begin_silence(self, at_sample: Optional[int] = None, push: bool = True) -> None:
+        if self.current_silence:
             return
-
-        if self.is_stopping:
-            logger.warning("AudioProcessor is stopping. Ignoring incoming audio.")
-            return
-
-        self.metrics.n_chunks_received += 1
-
-        if self.is_pcm_input:
-            self.pcm_buffer.extend(message)
-            await self.handle_pcm_data()
+        # Use audio stream time (sample-precise) for accurate silence duration
+        if at_sample is not None:
+            audio_t = at_sample / self.sample_rate
         else:
-            if not self.ffmpeg_manager:
-                logger.error("FFmpeg manager not initialized for non-PCM input.")
-                return
-            success = await self.ffmpeg_manager.write_data(message)
-            if not success:
-                ffmpeg_state = await self.ffmpeg_manager.get_state()
-                if ffmpeg_state == FFmpegState.FAILED:
-                    logger.error("FFmpeg is in FAILED state, cannot process audio")
-                else:
-                    logger.warning("Failed to write audio data to FFmpeg")
+            audio_t = self.get_audio_time()
+        self.current_silence = Silence(
+            is_starting=True, start=audio_t
+        )
+        if not push:
+            return
+        # Push a separate start-only event so _end_silence won't mutate it
+        start_event = Silence(is_starting=True, start=audio_t)
+        if self.transcription_queue:
+            await self.transcription_queue.put(start_event)
+        if self.diarization_queue:
+            await self.diarization_queue.put(start_event)
+
+    async def _end_silence(self, at_sample: Optional[int] = None) -> None:
+        if not self.current_silence:
+            return
+        if at_sample is not None:
+            audio_t = at_sample / self.sample_rate
+        else:
+            audio_t = self.get_audio_time()
+        self.current_silence.end = audio_t
+        self.current_silence.is_starting = False
+        self.current_silence.has_ended = True
+        self.current_silence.compute_duration()
+        self.metrics.n_silence_events += 1
+        if self.current_silence.duration is not None:
+            self.metrics.total_silence_duration_s += self.current_silence.duration
+        if self.current_silence.duration and self.current_silence.duration > MIN_DURATION_REAL_SILENCE:
+            self.aggregator.update_new_token(self.current_silence)
+        # Push the completed silence as the end event (separate from the start event)
+        await self._push_silence_event()
+        self.current_silence = None
+
+    async def _enqueue_active_audio(self, pcm_chunk: np.ndarray) -> None:
+        if pcm_chunk is None or pcm_chunk.size == 0:
+            return
+        if self.transcription_queue:
+            await self.transcription_queue.put(pcm_chunk.copy())
+        if self.diarization_queue:
+            await self.diarization_queue.put(pcm_chunk.copy())
 
     async def handle_pcm_data(self) -> None:
         # Without VAC, there's no speech detector to end the initial silence.
@@ -981,7 +403,7 @@ class AudioProcessor:
         if not self.args.transcription and not self.args.diarization:
             await asyncio.sleep(0.1)
 
-    async def _flush_remaining_pcm(self) -> None:
+    async def flush_remaining_pcm(self) -> None:
         """Flush whatever PCM data remains in the buffer, regardless of size threshold."""
         if not self.pcm_buffer:
             return
@@ -995,6 +417,674 @@ class AudioProcessor:
         if self.current_silence:
             await self._end_silence(at_sample=self.total_pcm_samples)
 
-        self.total_pcm_samples += len(pcm_array)
         await self._enqueue_active_audio(pcm_array)
+        self.total_pcm_samples += len(pcm_array)
         logger.info(f"Flushed remaining PCM buffer: {len(pcm_array)} samples ({len(pcm_array)/self.sample_rate:.2f}s)")
+
+    async def signal_input_complete(self) -> None:
+        """Signal end-of-input to the first active processing queue."""
+        if self.transcription_queue:
+            await self.transcription_queue.put(SENTINEL)
+            return
+        if self.diarization_queue:
+            await self.diarization_queue.put(SENTINEL)
+        if self.translation_queue:
+            await self.translation_queue.put(SENTINEL)
+
+
+class AudioIngester:
+    """Handles FFmpeg subprocess ingestion."""
+
+    def __init__(self, args, is_pcm_input: bool, chunker: VADChunker, aggregator: ResultAggregator):
+        self.args = args
+        self.is_pcm_input = is_pcm_input
+        self.chunker = chunker
+        self.aggregator = aggregator
+
+        self.ffmpeg_manager: Optional[FFmpegManager] = None
+        if not self.is_pcm_input:
+            self.ffmpeg_manager = FFmpegManager(
+                sample_rate=16000,
+                channels=1
+            )
+
+            async def handle_ffmpeg_error(error_type: str):
+                logger.error(f"FFmpeg error: {error_type}")
+                self.aggregator.ffmpeg_error = error_type
+            self.ffmpeg_manager.on_error_callback = handle_ffmpeg_error
+
+    async def ffmpeg_stdout_reader(self) -> None:
+        """Read audio data from FFmpeg stdout and process it into the PCM pipeline."""
+        beg = time()
+        cancelled = False
+        while True:
+            try:
+                state = await self.ffmpeg_manager.get_state() if self.ffmpeg_manager else FFmpegState.STOPPED
+                if state == FFmpegState.FAILED:
+                    logger.error("FFmpeg is in FAILED state, cannot read data")
+                    break
+                elif state == FFmpegState.STOPPED:
+                    logger.info("FFmpeg is stopped")
+                    break
+                elif state != FFmpegState.RUNNING:
+                    await asyncio.sleep(0.1)
+                    continue
+
+                current_time = time()
+                elapsed_time = max(0.0, current_time - beg)
+                buffer_size = max(int(32000 * elapsed_time), 4096)  # dynamic read
+                beg = current_time
+
+                chunk = await self.ffmpeg_manager.read_data(buffer_size)
+                if chunk is None:
+                    await asyncio.sleep(0.05)
+                    continue
+                if chunk == b"":
+                    logger.info("FFmpeg stdout reached EOF.")
+                    break
+
+                self.chunker.pcm_buffer.extend(chunk)
+                await self.chunker.handle_pcm_data()
+
+            except asyncio.CancelledError:
+                logger.info("ffmpeg_stdout_reader cancelled.")
+                cancelled = True
+                break
+            except Exception as e:
+                logger.warning(f"Exception in ffmpeg_stdout_reader: {e}")
+                logger.debug(f"Traceback: {traceback.format_exc()}")
+                await asyncio.sleep(0.2)
+
+        if cancelled:
+            return
+
+        await self.chunker.flush_remaining_pcm()
+        if self.ffmpeg_manager:
+            await self.ffmpeg_manager.stop()
+
+        logger.info("FFmpeg stdout processing finished. Signaling downstream processors if needed.")
+        await self.chunker.signal_input_complete()
+
+
+class TranscriptionWorker:
+    def __init__(self, transcription_backend, in_queue, aggregator: ResultAggregator, translation_queue, metrics: SessionMetrics, args):
+        self.transcription = transcription_backend
+        self.sep: str = transcription_backend.asr.sep
+        self.queue = in_queue
+        self.aggregator = aggregator
+        self.translation_queue = translation_queue
+        self.metrics = metrics
+        self.args = args
+        self.sample_rate = 16000
+        self.is_stopping = False
+        self.wants_hypothesis_tail = False
+
+        # Translate-on-segment-complete (issue #264): hold tokens until punctuation
+        self.translate_on_complete: bool = bool(getattr(self.args, "translate_on_complete", False))
+        self._pending_translation_tokens: List[ASRToken] = []
+        # Silent-backend watchdog: flips once ASR produces anything
+        self._any_asr_output: bool = False
+        self._silent_backend_warned: bool = False
+        self._SILENT_BACKEND_WARN_SECONDS = 20.0
+
+    async def _queue_tokens_for_translation(self, tokens: List[ASRToken]) -> None:
+        """Forward committed tokens to the translation queue.
+
+        With translate_on_complete, tokens are held back until a token
+        carrying punctuation closes the segment; the incomplete tail stays
+        pending and is not translated (issue #264).
+        """
+        if not self.translation_queue or not tokens:
+            return
+        if not self.translate_on_complete:
+            for token in tokens:
+                await self.translation_queue.put(token)
+            return
+        self._pending_translation_tokens.extend(tokens)
+        last_punctuation_idx = -1
+        for i, token in enumerate(self._pending_translation_tokens):
+            if token.has_punctuation():
+                last_punctuation_idx = i
+        if last_punctuation_idx >= 0:
+            for token in self._pending_translation_tokens[:last_punctuation_idx + 1]:
+                await self.translation_queue.put(token)
+            self._pending_translation_tokens = self._pending_translation_tokens[last_punctuation_idx + 1:]
+
+    def _warn_if_backend_silent(self, audio_seconds: float) -> None:
+        """One-time loud error when ASR consumed audio but never produced output."""
+        if self._silent_backend_warned or self._any_asr_output:
+            return
+        if audio_seconds < self._SILENT_BACKEND_WARN_SECONDS:
+            return
+        self._silent_backend_warned = True
+        logger.error(
+            "ASR backend produced no output after {:.0f} s of audio. The backend "
+            "is likely failing on every chunk; check earlier warnings for the "
+            "root cause (device mismatches, incompatible wheels, model load "
+            "errors).",
+            audio_seconds,
+        )
+
+    async def _flush_pending_translation_tokens(self) -> None:
+        """Release held-back tokens at a segment boundary (silence or end of stream)."""
+        if self.translation_queue and self._pending_translation_tokens:
+            for token in self._pending_translation_tokens:
+                await self.translation_queue.put(token)
+            self._pending_translation_tokens = []
+
+    async def _queue_hypothesis_tail_for_translation(self, buffer_transcript) -> None:
+        """Forward the unstable ASR tail to translation backends that opt in."""
+        if not self.translation_queue or not self.wants_hypothesis_tail:
+            return
+        text = (buffer_transcript.text or "").strip() if buffer_transcript else ""
+        if not text:
+            return
+        await self.translation_queue.put(
+            HypothesisTail(
+                start=buffer_transcript.start,
+                end=buffer_transcript.end,
+                text=text,
+            )
+        )
+
+    async def _finish_transcription(self) -> None:
+        """Call finish() on the online processor to flush remaining tokens."""
+        if not self.transcription:
+            return
+        try:
+            if hasattr(self.transcription, 'finish'):
+                final_tokens, end_time = await asyncio.to_thread(self.transcription.finish)
+            else:
+                # SimulStreamingOnlineProcessor uses start_silence() → process_iter(is_last=True)
+                final_tokens, end_time = await asyncio.to_thread(self.transcription.start_silence)
+
+            final_tokens = final_tokens or []
+            _buffer_transcript = self.transcription.get_buffer()
+
+            # Using aggregator's state purely for reading fallback condition
+            state = self.aggregator.state
+            if not final_tokens and state.buffer_transcription and state.buffer_transcription.text:
+                pending = state.buffer_transcription
+                text = pending.text.strip()
+                if text:
+                    start = pending.start if pending.start is not None else state.end_buffer
+                    end = pending.end if pending.end is not None else end_time
+                    if end is None or end < start:
+                        end = start
+                    final_tokens = [
+                        ASRToken(
+                            start=start,
+                            end=end,
+                            text=text,
+                            detected_language=pending.detected_language,
+                        )
+                    ]
+                    _buffer_transcript = Transcript()
+            self.aggregator.update_transcription_time(
+                new_tokens=final_tokens,
+                current_audio_processed_upto=end_time
+            )
+            if final_tokens:
+                logger.info(f"Finish flushed {len(final_tokens)} tokens")
+                self.metrics.n_tokens_produced += len(final_tokens)
+                candidate_end_times = [self.aggregator.state.end_buffer, end_time]
+                self.aggregator.update_transcription(
+                    final_tokens, _buffer_transcript, candidate_end_times, end_time
+                )
+                if self.translation_queue:
+                    await self._queue_tokens_for_translation(final_tokens)
+            # End of stream finalizes the last segment even without punctuation
+            await self._flush_pending_translation_tokens()
+        except Exception as e:
+            logger.warning(f"Error finishing transcription: {e}")
+            logger.debug(f"Traceback: {traceback.format_exc()}")
+
+    async def run(self) -> None:
+        """Process audio chunks for transcription."""
+        cumulative_pcm_duration_stream_time = 0.0
+
+        while True:
+            try:
+                # Use a timeout so we periodically wake up and refresh the
+                # buffer state.  Streaming backends (e.g. voxtral) may
+                # produce text tokens asynchronously; without a periodic
+                # drain, those tokens would sit unread until the next audio
+                # chunk arrives — causing the frontend to show nothing.
+                try:
+                    item = await asyncio.wait_for(
+                        get_all_from_queue(self.queue),
+                        timeout=0.5,
+                    )
+                except asyncio.TimeoutError:
+                    # No new audio — just refresh buffer for streaming backends
+                    _buffer_transcript = self.transcription.get_buffer()
+                    self.aggregator.update_buffer_transcription(_buffer_transcript)
+                    continue
+
+                if item is SENTINEL:
+                    logger.debug("Transcription processor received sentinel. Finishing.")
+                    await self._finish_transcription()
+                    break
+
+                asr_internal_buffer_duration_s = len(
+                    getattr(self.transcription, 'audio_buffer', [])) / self.transcription.SAMPLING_RATE
+                transcription_lag_s = max(0.0, time() - self.aggregator.beg_loop - self.aggregator.state.end_buffer)
+                asr_processing_logs = f"internal_buffer={asr_internal_buffer_duration_s:.2f}s | lag={transcription_lag_s:.2f}s |"
+                stream_time_end_of_current_pcm = cumulative_pcm_duration_stream_time
+                new_tokens = []
+                current_audio_processed_upto = self.aggregator.state.end_buffer
+
+                if isinstance(item, Silence):
+                    await self._flush_pending_translation_tokens()
+                    if self.translation_queue:
+                        await self.translation_queue.put(item)
+
+                    if item.is_starting:
+                        new_tokens, current_audio_processed_upto = await asyncio.to_thread(
+                            self.transcription.start_silence
+                        )
+                        asr_processing_logs += " + Silence starting"
+                    if item.has_ended:
+                        asr_processing_logs += f" + Silence of = {item.duration:.2f}s"
+                        cumulative_pcm_duration_stream_time += item.duration
+                        current_audio_processed_upto = cumulative_pcm_duration_stream_time
+                        last_end = self.aggregator.state.tokens[-1].end if self.aggregator.state.tokens else 0
+                        self.transcription.end_silence(item.duration, last_end)
+                    if self.aggregator.state.tokens:
+                        asr_processing_logs += f" | last_end = {self.aggregator.state.tokens[-1].end:.2f} |"
+                    logger.info(asr_processing_logs)
+                    new_tokens = new_tokens or []
+                    current_audio_processed_upto = max(current_audio_processed_upto, stream_time_end_of_current_pcm)
+                elif isinstance(item, ChangeSpeaker):
+                    self.transcription.new_speaker(item)
+                    continue
+                elif isinstance(item, np.ndarray):
+                    pcm_array = item
+                    logger.info(asr_processing_logs)
+                    cumulative_pcm_duration_stream_time += len(pcm_array) / self.sample_rate
+                    stream_time_end_of_current_pcm = cumulative_pcm_duration_stream_time
+                    self.transcription.insert_audio_chunk(pcm_array, stream_time_end_of_current_pcm)
+                    _t0 = time()
+                    new_tokens, current_audio_processed_upto = await asyncio.to_thread(self.transcription.process_iter)
+                    _dur = time() - _t0
+                    self.metrics.transcription_durations.append(_dur)
+                    self.metrics.n_transcription_calls += 1
+                    new_tokens = new_tokens or []
+                    self.metrics.n_tokens_produced += len(new_tokens)
+
+                _buffer_transcript = self.transcription.get_buffer()
+                buffer_text = _buffer_transcript.text
+
+                if new_tokens:
+                    validated_text = self.sep.join([t.text for t in new_tokens])
+                    if buffer_text.startswith(validated_text):
+                        _buffer_transcript.text = buffer_text[len(validated_text):].lstrip()
+
+                candidate_end_times = [self.aggregator.state.end_buffer, ]
+
+                if new_tokens:
+                    candidate_end_times.append(new_tokens[-1].end)
+
+                if _buffer_transcript.end is not None:
+                    candidate_end_times.append(_buffer_transcript.end)
+
+                candidate_end_times.append(current_audio_processed_upto)
+
+                self.aggregator.update_transcription(
+                    new_tokens, _buffer_transcript, candidate_end_times, current_audio_processed_upto
+                )
+
+                if new_tokens or buffer_text.strip():
+                    self._any_asr_output = True
+                else:
+                    self._warn_if_backend_silent(cumulative_pcm_duration_stream_time)
+
+                await self._queue_tokens_for_translation(new_tokens)
+                await self._queue_hypothesis_tail_for_translation(_buffer_transcript)
+            except Exception as e:
+                logger.warning(f"Exception in transcription_processor: {e}")
+                logger.warning(f"Traceback: {traceback.format_exc()}")
+                if 'pcm_array' in locals() and pcm_array is not SENTINEL:  # Check if pcm_array was assigned from queue
+                    self.queue.task_done()
+
+        if self.is_stopping:
+            logger.info("Transcription processor finishing due to stopping flag.")
+            if self.aggregator.chunker_ref.diarization_queue:
+                await self.aggregator.chunker_ref.diarization_queue.put(SENTINEL)
+            if self.translation_queue:
+                await self.translation_queue.put(SENTINEL)
+
+        logger.info("Transcription processor task finished.")
+
+
+class DiarizationWorker:
+    def __init__(self, diarization_backend, in_queue, aggregator: ResultAggregator):
+        self.diarization = diarization_backend
+        self.queue = in_queue
+        self.aggregator = aggregator
+
+    async def _drain_diarization_buffer(self) -> None:
+        """Process all remaining audio in the diarization buffer.
+        Sortformer-style backends accumulate audio in an internal buffer and
+        process one chunk per ``diarize()`` call, returning ``[]`` when the
+        buffer is too short.  This helper loops until the buffer is fully
+        consumed.
+        """
+        while True:
+            diarization_segments = await self.diarization.diarize()
+            if not diarization_segments:
+                break
+            diar_end = max(getattr(s, "end", 0.0) for s in diarization_segments)
+            self.aggregator.append_diarization(diarization_segments, diar_end)
+
+    async def run(self) -> None:
+        has_buffer = hasattr(self.diarization, 'buffer_audio')
+        while True:
+            try:
+                item = await get_all_from_queue(self.queue)
+                if item is SENTINEL:
+                    break
+                elif isinstance(item, Silence):
+                    if item.has_ended:
+                        self.diarization.insert_silence(item.duration)
+                    continue
+                self.diarization.insert_audio_chunk(item)
+                if has_buffer:
+                    await self._drain_diarization_buffer()
+                else:
+                    # Cumulative backends (e.g. Diart): replace, not extend
+                    diarization_segments = await self.diarization.diarize()
+                    diar_end = 0.0
+                    if diarization_segments:
+                        diar_end = max(getattr(s, "end", 0.0) for s in diarization_segments)
+                    self.aggregator.replace_diarization(diarization_segments, diar_end)
+
+            except Exception as e:
+                logger.warning(f"Exception in diarization_processor: {e}")
+                logger.warning(f"Traceback: {traceback.format_exc()}")
+        # Drain any remaining audio in the buffer before exiting
+        if has_buffer:
+            try:
+                await self._drain_diarization_buffer()
+            except Exception as e:
+                logger.warning(f"Exception draining diarization buffer: {e}")
+        logger.info("Diarization processor task finished.")
+
+
+class TranslationWorker:
+    def __init__(self, translation_backend, in_queue, aggregator: ResultAggregator):
+        self.translation = translation_backend
+        self.queue = in_queue
+        self.aggregator = aggregator
+
+    async def run(self) -> None:
+        # the idea is to ignore diarization for the moment. We use only transcription tokens.
+        # And the speaker is attributed given the segments used for the translation
+        # in the future we want to have different languages for each speaker etc, so it will be more complex.
+        while True:
+            try:
+                item = await get_all_from_queue(self.queue)
+                if item is SENTINEL:
+                    logger.debug("Translation processor received sentinel. Finishing.")
+                    break
+
+                new_translation = None
+                new_translation_buffer = None
+
+                if isinstance(item, Silence):
+                    if item.is_starting:
+                        new_translation, new_translation_buffer = self.translation.validate_buffer_and_reset()
+                    if item.has_ended:
+                        self.translation.insert_silence(item.duration)
+                        continue
+                elif isinstance(item, ChangeSpeaker):
+                    new_translation, new_translation_buffer = self.translation.validate_buffer_and_reset()
+                else:
+                    self.translation.insert_tokens(item)
+                    new_translation, new_translation_buffer = await asyncio.to_thread(self.translation.process)
+
+                if new_translation is not None:
+                    self.aggregator.update_translation(new_translation, new_translation_buffer)
+            except Exception as e:
+                logger.warning(f"Exception in translation_processor: {e}")
+                logger.warning(f"Traceback: {traceback.format_exc()}")
+        logger.info("Translation processor task finished.")
+
+
+class AudioProcessor:
+    """Orchestrates ingestion, chunking, decoupled workers, and state aggregation."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        # Extract per-session options before passing to TranscriptionEngine
+        session_language = kwargs.pop('language', None)
+        # Output mode: "full" resends whole transcript on every update, so history
+        # must never be pruned away (issue #372); "diff" clients keep their own copy.
+        session_mode = kwargs.pop('mode', 'full')
+        session_target_language = kwargs.pop('target_language', None)
+
+        if 'transcription_engine' in kwargs and isinstance(kwargs['transcription_engine'], TranscriptionEngine):
+            models = kwargs['transcription_engine']
+        else:
+            models = TranscriptionEngine(**kwargs)
+
+        self.args = models.args
+        self.is_pcm_input = self.args.pcm_input
+        self.metrics: SessionMetrics = SessionMetrics()
+
+        # Initialize core components
+        self.aggregator = ResultAggregator(self.args, self.metrics, session_mode)
+        self.chunker = VADChunker(self.args, models.vac_session if self.args.vac else None, self.metrics)
+        self.aggregator.chunker_ref = self.chunker
+        self.chunker.aggregator = self.aggregator
+        self.ingester = AudioIngester(self.args, self.is_pcm_input, self.chunker, self.aggregator)
+
+        # Initialize Queues
+        if self.args.transcription:
+            self.chunker.transcription_queue = asyncio.Queue()
+        if self.args.diarization:
+            self.chunker.diarization_queue = asyncio.Queue()
+        # translation queue created if server has translation or session requests it
+        if self.args.target_language or session_target_language:
+            self.chunker.translation_queue = asyncio.Queue()
+
+        # Initialize Workers
+        self.transcription_worker = None
+        self.diarization_worker = None
+        self.translation_worker = None
+
+        if self.args.transcription:
+            transcription_backend = online_factory(self.args, models.asr, language=session_language)
+            self.transcription_worker = TranscriptionWorker(
+                transcription_backend,
+                self.chunker.transcription_queue,
+                self.aggregator,
+                self.chunker.translation_queue,
+                self.metrics,
+                self.args
+            )
+
+        if self.args.diarization:
+            self.diarization_worker = DiarizationWorker(
+                online_diarization_factory(self.args, models.diarization_model),
+                self.chunker.diarization_queue,
+                self.aggregator
+            )
+
+        if models.translation_model:
+            if session_target_language and session_target_language != self.args.target_language:
+                from whisperlivekit.translation import session_translation_factory
+                translation_backend = session_translation_factory(
+                    self.args, models.translation_model, session_target_language
+                )
+            else:
+                translation_backend = online_translation_factory(self.args, models.translation_model)
+            self.translation_worker = TranslationWorker(
+                translation_backend,
+                self.chunker.translation_queue,
+                self.aggregator
+            )
+            self.aggregator.has_translation = True
+            if self.transcription_worker:
+                self.transcription_worker.wants_hypothesis_tail = getattr(
+                    translation_backend, "wants_hypothesis_tail", False)
+
+        elif session_target_language:
+            logger.warning(
+                "Session requested target_language=%r but the server was started "
+                "without translation (--target-language); ignoring.",
+                session_target_language,
+            )
+
+        self.all_tasks_for_cleanup: List[asyncio.Task] = []
+
+    def _processing_tasks_done(self) -> bool:
+        """Callback for aggregator to know when to exit."""
+        tasks = [
+            t for t in self.all_tasks_for_cleanup
+            if t and not t.done() and t.get_name() != "watchdog"
+        ]
+        return len(tasks) == 0
+
+    async def create_tasks(self) -> AsyncGenerator[FrontData, None]:
+        """Create and start processing tasks."""
+        self.all_tasks_for_cleanup = []
+        processing_tasks_for_watchdog: List[asyncio.Task] = []
+
+        # If using FFmpeg (non-PCM input), start it and spawn stdout reader
+        if not self.is_pcm_input:
+            success = await self.ingester.ffmpeg_manager.start()
+            if not success:
+                logger.error("Failed to start FFmpeg manager")
+
+                async def error_generator() -> AsyncGenerator[FrontData, None]:
+                    yield FrontData(
+                        status="error",
+                        error="FFmpeg failed to start. Please check that FFmpeg is installed."
+                    )
+                return error_generator()
+            task = asyncio.create_task(self.ingester.ffmpeg_stdout_reader(), name="ffmpeg_reader")
+            self.all_tasks_for_cleanup.append(task)
+            processing_tasks_for_watchdog.append(task)
+
+        if self.transcription_worker:
+            task = asyncio.create_task(self.transcription_worker.run(), name="transcription")
+            self.all_tasks_for_cleanup.append(task)
+            processing_tasks_for_watchdog.append(task)
+
+        if self.diarization_worker:
+            task = asyncio.create_task(self.diarization_worker.run(), name="diarization")
+            self.all_tasks_for_cleanup.append(task)
+            processing_tasks_for_watchdog.append(task)
+
+        if self.translation_worker:
+            task = asyncio.create_task(self.translation_worker.run(), name="translation")
+            self.all_tasks_for_cleanup.append(task)
+            processing_tasks_for_watchdog.append(task)
+
+        # Monitor overall system health
+        watchdog_task = asyncio.create_task(self.watchdog(processing_tasks_for_watchdog), name="watchdog")
+        self.all_tasks_for_cleanup.append(watchdog_task)
+
+        return self.aggregator.format_results(self._processing_tasks_done)
+
+    async def watchdog(self, tasks_to_monitor: List[asyncio.Task]) -> None:
+        """Monitors the health of critical processing tasks."""
+        tasks_remaining: List[asyncio.Task] = [task for task in tasks_to_monitor if task]
+        while True:
+            try:
+                if not tasks_remaining:
+                    logger.info("Watchdog task finishing: all monitored tasks completed.")
+                    return
+
+                await asyncio.sleep(10)
+
+                for i, task in enumerate(list(tasks_remaining)):
+                    if task.done():
+                        exc = task.exception()
+                        task_name = task.get_name() if hasattr(task, 'get_name') else f"Monitored Task {i}"
+                        if exc:
+                            logger.error(f"{task_name} unexpectedly completed with exception: {exc}")
+                        else:
+                            logger.info(f"{task_name} completed normally.")
+                        tasks_remaining.remove(task)
+
+            except asyncio.CancelledError:
+                logger.info("Watchdog task cancelled.")
+                break
+            except Exception as e:
+                logger.error(f"Error in watchdog task: {e}", exc_info=True)
+
+    async def cleanup(self) -> None:
+        """Clean up resources when processing is complete."""
+        logger.info("Starting cleanup of AudioProcessor resources.")
+        self.aggregator.is_stopping = True
+        if self.transcription_worker:
+            self.transcription_worker.is_stopping = True
+        for task in self.all_tasks_for_cleanup:
+            if task and not task.done():
+                task.cancel()
+
+        created_tasks = [t for t in self.all_tasks_for_cleanup if t]
+        if created_tasks:
+            await asyncio.gather(*created_tasks, return_exceptions=True)
+        logger.info("All processing tasks cancelled or finished.")
+
+        if not self.is_pcm_input and self.ingester.ffmpeg_manager:
+            try:
+                await self.ingester.ffmpeg_manager.stop()
+                logger.info("FFmpeg manager stopped.")
+            except Exception as e:
+                logger.warning(f"Error stopping FFmpeg manager: {e}")
+        if self.diarization_worker:
+            self.diarization_worker.diarization.close()
+
+        # Finalize session metrics
+        self.metrics.total_audio_duration_s = self.chunker.total_pcm_samples / self.chunker.sample_rate
+        self.metrics.log_summary()
+        logger.info("AudioProcessor cleanup complete.")
+
+    async def process_audio(self, message: Optional[bytes]) -> None:
+        """Process incoming audio data."""
+
+        if not self.aggregator.beg_loop:
+            self.aggregator.beg_loop = time()
+            self.metrics.session_start = self.aggregator.beg_loop
+            await self.chunker._begin_silence(at_sample=0, push=False)
+            self.aggregator.tokens_alignment.beg_loop = self.aggregator.beg_loop
+
+        if not message:
+            logger.info("Empty audio message received, initiating stop sequence.")
+            self.aggregator.is_stopping = True
+            if self.transcription_worker:
+                self.transcription_worker.is_stopping = True
+
+            # Flush any remaining PCM data before signaling end-of-stream
+            if self.is_pcm_input:
+                if self.chunker.pcm_buffer:
+                    await self.chunker.flush_remaining_pcm()
+                await self.chunker.signal_input_complete()
+            elif self.ingester.ffmpeg_manager:
+                await self.ingester.ffmpeg_manager.close_stdin()
+
+            return
+
+        if self.aggregator.is_stopping:
+            logger.warning("AudioProcessor is stopping. Ignoring incoming audio.")
+            return
+
+        self.metrics.n_chunks_received += 1
+
+        if self.is_pcm_input:
+            self.chunker.pcm_buffer.extend(message)
+            await self.chunker.handle_pcm_data()
+        else:
+            if not self.ingester.ffmpeg_manager:
+                logger.error("FFmpeg manager not initialized for non-PCM input.")
+                return
+            success = await self.ingester.ffmpeg_manager.write_data(message)
+            if not success:
+                ffmpeg_state = await self.ingester.ffmpeg_manager.get_state()
+                if ffmpeg_state == FFmpegState.FAILED:
+                    logger.error("FFmpeg is in FAILED state, cannot process audio")
+                else:
+                    logger.warning("Failed to write audio data to FFmpeg")


### PR DESCRIPTION
## Summary

This PR refactors the previously monolithic `AudioProcessor` architecture to reduce coupling between modules, improve code readability and maintainability. The refactored version maintains compatibility with v0.2.25 in terms of API and overall processing flow.

## Architectural Changes

The multiple responsibilities previously handled by `AudioProcessor` have been split into dedicated classes:

* **`ResultAggregator`**: Centralizes shared state management. Replaces the previous `asyncio.Lock`-based approach with atomic synchronous update methods and provides a clean interface for reading state.
* **`VADChunker`**: Handles PCM buffer management, audio chunking, and VAD silence detection.
* **`AudioIngester`**: Manages the FFmpeg subprocess and audio stream reading.
* **Dedicated Workers**: TranscriptionWorker, DiarizationWorker, and TranslationWorker

## Testing & Verification

* Passed `pytest tests/ -v`
* Updated test scripts to align with the new architecture.
