### PR TITLE
chore: constrain Docker dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,12 @@ updates:
     groups:
       docker-images:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # Keep the container runtime aligned with the cu129 PyTorch extra.
+      # CUDA major upgrades need an explicit compatibility review.
+      - dependency-name: "nvidia/cuda"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "docker"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.10.4 AS uvbin
+FROM ghcr.io/astral-sh/uv:0.12.3 AS uvbin
 
 # --- MARK: Builder Stage
 FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04 AS builder-gpu

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.10.4 AS uvbin
+FROM ghcr.io/astral-sh/uv:0.12.3 AS uvbin
 
 # --- MARK: Builder Stage
 FROM debian:bookworm-slim AS builder-cpu


### PR DESCRIPTION
## Summary

- update the `uv` Docker helper image from 0.10.4 to 0.12.3
- keep NVIDIA CUDA on 12.9 so the container remains aligned with the `cu129` PyTorch extra
- limit grouped Docker updates to minor and patch releases
- require an explicit compatibility review before any CUDA major upgrade

## Why

Dependabot #401 grouped a routine `uv` update with CUDA 12.9.1 to 13.3.1. The GPU image, README, lock sources, and default Docker extra are intentionally built around `cu129`, so that major runtime change should not be accepted as an automatic grouped update.

## Validation

- parsed `.github/dependabot.yml` and asserted the Docker policy fields
- `uv lock --check`
- `git diff --check`
- full `Dockerfile.cpu` build with `--pull`
- container smoke checks: `uv 0.12.3`, `torch 2.11.0+cpu`, package import, and `wlk --help`

The temporary local image was removed after validation.