### PR TITLE
fix: consume LocalAgreement buffer at EOF

### DIFF
--- a/tests/test_asr_coalescing_boundaries.py
+++ b/tests/test_asr_coalescing_boundaries.py
@@ -236,6 +236,32 @@ def test_local_agreement_new_speaker_returns_tokens_and_position():
     assert processor.get_buffer().text == ""
 
 
+@pytest.mark.asyncio
+async def test_local_agreement_eof_consumes_published_buffer():
+    from whisperlivekit.local_agreement.online_asr import OnlineASRProcessor
+
+    class FakeASR:
+        sep = " "
+        tokenizer = None
+        confidence_validation = False
+        buffer_trimming = "segment"
+        buffer_trimming_sec = 15.0
+
+    backend = OnlineASRProcessor(FakeASR())
+    pending = ASRToken(0.0, 0.2, "tail")
+    backend.transcript_buffer.buffer = [pending]
+    backend.audio_buffer = np.zeros(3_200, dtype=np.float32)
+    processor = _processor_for(backend)
+    processor.state.buffer_transcription = backend.get_buffer()
+
+    await processor._finish_transcription()
+
+    assert processor.state.tokens == [pending]
+    assert processor.state.end_transcription_processed == pytest.approx(0.2)
+    assert processor.state.buffer_transcription.text == ""
+    _assert_asr_metrics(processor, calls=1, tokens=1)
+
+
 def test_simulstreaming_new_speaker_returns_tokens_and_position():
     from whisperlivekit.simul_whisper.backend import SimulStreamingOnlineProcessor
 

--- a/whisperlivekit/funasr_backend.py
+++ b/whisperlivekit/funasr_backend.py
@@ -265,9 +265,4 @@ class FunASRASR:
 
 
 class FunASROnlineASRProcessor(OnlineASRProcessor):
-    """Prevent SenseVoice's committed EOF batch from remaining pending."""
-
-    def finish(self):
-        remaining_tokens, final_processed_upto = super().finish()
-        self.transcript_buffer.buffer = []
-        return remaining_tokens, final_processed_upto
+    """LocalAgreement processor specialization for SenseVoice."""

--- a/whisperlivekit/local_agreement/online_asr.py
+++ b/whisperlivekit/local_agreement/online_asr.py
@@ -403,6 +403,7 @@ class OnlineASRProcessor:
         Returns a tuple: (list of remaining ASRToken objects, float representing the final audio processed up to time).
         """
         remaining_tokens = self.transcript_buffer.buffer
+        self.transcript_buffer.buffer = []
         logger.debug(f"Final non-committed tokens: {remaining_tokens}")
         final_processed_upto = self.buffer_time_offset + (len(self.audio_buffer) / self.SAMPLING_RATE)
         self.buffer_time_offset = final_processed_upto


### PR DESCRIPTION
## Summary

- consume pending LocalAgreement tokens when `finish()` returns them;
- prevent the same EOF token from appearing in both committed output and `buffer_transcription`;
- verify the complete AudioProcessor publication path with a deterministic regression test;
- remove the now-redundant SenseVoice `finish()` override while preserving its public processor class.

## Root cause

`OnlineASRProcessor.finish()` returned `transcript_buffer.buffer` without clearing it. The audio processor committed those returned tokens, then the result formatter read the same buffer again. Depending on how many hypotheses had stabilized before EOF, the final word could be displayed twice.

## Validation

- `ruff check .`
- focused LocalAgreement, AudioProcessor, and FunASR tests: 49 passed, 3 skipped
- real Faster-Whisper EOF pipeline: baseline and coalesced output both end with `young princess. The French in return`, with no duplicate final word
- full dependency-light suite: 177 passed, 14 skipped
- real SenseVoice suite: 9 passed