### PR TITLE
feat: add configurable pause segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ async def websocket_endpoint(websocket: WebSocket):
 | `--diarization` | Enable speaker identification | `False` |
 | `--backend-policy` | Streaming strategy: `1`/`simulstreaming` uses AlignAtt SimulStreaming, `2`/`localagreement` uses the LocalAgreement policy | `simulstreaming` |
 | `--backend` | ASR backend selector. `auto` picks MLX on macOS (if installed), otherwise Faster-Whisper, otherwise vanilla Whisper. Options: `mlx-whisper`, `faster-whisper`, `whisper`, `openai-api` (LocalAgreement only), `funasr` (SenseVoiceSmall, LocalAgreement only), `voxtral-mlx` (Apple Silicon), `voxtral` (HuggingFace), `qwen3-vllm`, `qwen3-vllm-metal` (Apple Silicon), `qwen3-streaming` (HuggingFace, CUDA/MPS/CPU), `canary` (NeMo, CUDA/CPU, LocalAgreement only) | `auto` |
+| `--pause-segmentation-seconds` | Create a stable transcript boundary when a VAD pause is longer than this many seconds. Use `0` to disable pause-based segmentation. | `5.0` |
 | `--asr-coalesce-min-s` | Defer an ASR call until this much new audio has accrued. Trades update cadence for fewer encoder passes; use `0` to disable. | `0` |
 | `--no-vac` | Disable Voice Activity Controller. NOT ADVISED | `False` |
 | `--no-vad` | Disable Voice Activity Detection. NOT ADVISED | `False` |

--- a/docs/API.md
+++ b/docs/API.md
@@ -119,7 +119,9 @@ curl http://localhost:8000/health
 
 ### WS /v1/listen
 
-Drop-in compatible with Deepgram's Live Transcription WebSocket. Connect using any Deepgram client SDK pointed at your local server.
+Compatibility-oriented subset of Deepgram's Live Transcription WebSocket.
+Current Deepgram client SDKs can connect when they use only the parameters and
+messages documented below.
 
 ```python
 from deepgram import DeepgramClient, LiveOptions
@@ -129,7 +131,16 @@ connection = deepgram.listen.websocket.v("1")
 connection.start(LiveOptions(model="nova-2", language="en"))
 ```
 
-**Query Parameters:** Same as Deepgram (`language`, `punctuate`, `interim_results`, `vad_events`, etc.).
+**Supported Query Parameters:**
+
+- `language`: per-session source language
+- `vad_events=true`: emit `SpeechStarted` events
+
+Deepgram's `endpointing` and `utterance_end_ms` parameters are not implemented and
+do not control `--pause-segmentation-seconds`. WhisperLiveKit currently marks every
+committed `Results` message as `speech_final` and emits its existing
+`UtteranceEnd` event from VAD-derived silence lines. These are compatibility
+approximations, not Deepgram's separate endpointing and word-gap timers.
 
 **Client Messages:**
 - Binary audio frames
@@ -572,7 +583,9 @@ After applying a diff, check that `len(lines) == msg["n_lines"]`. A mismatch ind
 
 ## Silence Representation
 
-Silence segments are represented as lines with `speaker` set to `-2` and `text` set to `null`:
+Silence segments are represented as lines with `speaker` set to `-2`. Their
+`text` is `null` with diarization and an empty string without diarization, so
+clients should identify them by `speaker`:
 
 ```json
 {
@@ -583,7 +596,15 @@ Silence segments are represented as lines with `speaker` set to `-2` and `text` 
 }
 ```
 
-Silence segments are only generated for pauses longer than 5 seconds.
+Silence segments are generated when a VAD pause is longer than
+`--pause-segmentation-seconds`, which defaults to 5 seconds. The qualifying pause
+creates one stable line boundary without changing word text or timestamps, both
+with and without diarization. Use `--pause-segmentation-seconds 0` to disable these
+boundaries. The boundary is committed after the pause ends, when speech resumes
+or end of input is received; an in-progress pause is not added to `lines`. The
+native `/asr` WebSocket uses the server-wide setting. The
+Deepgram-compatible `/v1/listen` endpoint uses the same server-wide setting;
+Deepgram's `endpointing` query parameter is not mapped to it.
 
 ---
 

--- a/tests/test_pause_segmentation.py
+++ b/tests/test_pause_segmentation.py
@@ -1,0 +1,418 @@
+"""Pause-based transcript segmentation regressions for issue #409."""
+
+import asyncio
+import math
+import sys
+from time import time
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from whisperlivekit.audio_processor import (
+    MIN_DURATION_REAL_SILENCE,
+    SENTINEL,
+    AudioProcessor,
+)
+from whisperlivekit.config import WhisperLiveKitConfig
+from whisperlivekit.diff_protocol import DiffTracker
+from whisperlivekit.metrics_collector import SessionMetrics
+from whisperlivekit.test_client import reconstruct_state
+from whisperlivekit.timed_objects import (
+    ASRToken,
+    FrontData,
+    Silence,
+    SpeakerSegment,
+    State,
+    Transcript,
+)
+from whisperlivekit.tokens_alignment import TokensAlignment
+
+
+def test_pause_segmentation_config_preserves_default():
+    config = WhisperLiveKitConfig()
+
+    assert config.pause_segmentation_seconds == 5.0
+    assert config.pause_segmentation_seconds == MIN_DURATION_REAL_SILENCE
+
+
+@pytest.mark.parametrize("value", [-0.1, math.inf, -math.inf, math.nan, "invalid"])
+def test_pause_segmentation_config_rejects_invalid_values(value):
+    with pytest.raises(
+        ValueError,
+        match="pause_segmentation_seconds must be finite and non-negative",
+    ):
+        WhisperLiveKitConfig(pause_segmentation_seconds=value)
+
+
+def test_parse_args_accepts_pause_segmentation_seconds(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["wlk", "--pause-segmentation-seconds", "1.25"],
+    )
+
+    from whisperlivekit.parse_args import parse_args
+
+    assert parse_args().pause_segmentation_seconds == 1.25
+
+
+def _silence_processor(threshold: float) -> AudioProcessor:
+    processor = object.__new__(AudioProcessor)
+    processor.pause_segmentation_seconds = threshold
+    processor.sample_rate = 100
+    processor.total_pcm_samples = 0
+    processor.current_silence = Silence(start=1.0, is_starting=True)
+    processor.metrics = SessionMetrics()
+    processor.state = State()
+    processor.args = SimpleNamespace(diarization=False, vac=True)
+    processor.transcription_queue = None
+    processor.diarization_queue = None
+    processor.translation_queue = None
+    processor.vac = lambda _pcm: []
+    return processor
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("threshold", "duration", "expected_boundaries"),
+    [
+        (2.0, 1.99, 0),
+        (2.0, 2.0, 0),
+        (2.0, 2.01, 1),
+        (0.0, 10.0, 0),
+    ],
+)
+async def test_completed_pause_threshold_is_deterministic(
+    threshold,
+    duration,
+    expected_boundaries,
+):
+    processor = _silence_processor(threshold)
+
+    await processor._end_silence(at_sample=round((1.0 + duration) * 100))
+
+    assert len(processor.state.new_tokens) == expected_boundaries
+    assert processor.current_silence is None
+    assert processor.metrics.n_silence_events == 1
+
+
+class _BoundaryASR:
+    SAMPLING_RATE = 16_000
+
+    def __init__(self):
+        self.audio_buffer = np.array([], dtype=np.float32)
+        self.committed_before_pause = ASRToken(0.0, 1.0, "before")
+
+    def start_silence(self):
+        return [self.committed_before_pause], 1.0
+
+    def end_silence(self, duration, offset):
+        self.ended_silence = (duration, offset)
+
+    def finish(self):
+        return [], 3.5
+
+    def get_buffer(self):
+        return Transcript()
+
+
+def _boundary_processor(
+    *,
+    translation: bool = False,
+    translate_on_complete: bool = False,
+) -> AudioProcessor:
+    processor = object.__new__(AudioProcessor)
+    processor.args = SimpleNamespace(asr_coalesce_min_s=0.0)
+    processor.pause_segmentation_seconds = 2.0
+    processor.transcription = _BoundaryASR()
+    processor.transcription_queue = asyncio.Queue()
+    processor.translation_queue = asyncio.Queue() if translation else None
+    processor.translation = None
+    processor.translate_on_complete = translate_on_complete
+    processor._pending_translation_tokens = []
+    processor.diarization_queue = None
+    processor.metrics = SessionMetrics()
+    processor.state = State()
+    processor.lock = asyncio.Lock()
+    processor.sample_rate = 16_000
+    processor.beg_loop = time()
+    processor.sep = " "
+    processor.is_stopping = False
+    processor._any_asr_output = False
+    processor._silent_backend_warned = False
+    processor._prune_state_tokens = lambda: None
+    return processor
+
+
+@pytest.mark.asyncio
+async def test_boundary_is_published_after_words_flushed_at_silence_start():
+    processor = _boundary_processor()
+
+    pause = Silence(
+        start=1.0,
+        end=3.5,
+        duration=2.5,
+        has_ended=True,
+    )
+    await processor.transcription_queue.put(Silence(start=1.0, is_starting=True))
+    await processor.transcription_queue.put(pause)
+    await processor.transcription_queue.put(SENTINEL)
+
+    await processor.transcription_processor()
+
+    assert processor.state.new_tokens == [
+        processor.transcription.committed_before_pause,
+        pause,
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("translate_on_complete", [False, True])
+async def test_translation_boundary_follows_words_flushed_at_silence_start(
+    translate_on_complete,
+):
+    processor = _boundary_processor(
+        translation=True,
+        translate_on_complete=translate_on_complete,
+    )
+    start = Silence(start=1.0, is_starting=True)
+    pause = Silence(
+        start=1.0,
+        end=3.5,
+        duration=2.5,
+        has_ended=True,
+    )
+    await processor.transcription_queue.put(start)
+    await processor.transcription_queue.put(pause)
+    await processor.transcription_queue.put(SENTINEL)
+
+    await processor.transcription_processor()
+
+    queued = []
+    while not processor.translation_queue.empty():
+        queued.append(processor.translation_queue.get_nowait())
+    assert queued == [
+        processor.transcription.committed_before_pause,
+        start,
+        pause,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_eof_tail_extends_active_silence_before_committing_boundary():
+    processor = _silence_processor(0.65)
+    processor.current_silence = Silence(start=0.4, is_starting=True)
+    processor.total_pcm_samples = 100
+    processor.bytes_per_sample = 2
+    processor.pcm_buffer = bytearray(np.zeros(10, dtype=np.int16).tobytes())
+    enqueued_audio = []
+
+    async def capture_audio(chunk):
+        enqueued_audio.append(chunk)
+
+    processor._enqueue_active_audio = capture_audio
+
+    await processor._flush_remaining_pcm()
+
+    assert processor.total_pcm_samples == 110
+    assert processor.current_silence is None
+    assert len(processor.state.new_tokens) == 1
+    boundary = processor.state.new_tokens[0]
+    assert boundary.start == 0.4
+    assert boundary.end == 1.1
+    assert boundary.duration == pytest.approx(0.7)
+    assert enqueued_audio == []
+
+
+@pytest.mark.asyncio
+async def test_eof_tail_honors_vad_speech_start_and_enqueues_active_suffix():
+    processor = _silence_processor(0.6)
+    processor.current_silence = Silence(start=0.4, is_starting=True)
+    processor.total_pcm_samples = 100
+    processor.bytes_per_sample = 2
+    processor.pcm_buffer = bytearray(np.arange(10, dtype=np.int16).tobytes())
+    processor.vac = lambda _pcm: [{"start": 105}]
+    enqueued_audio = []
+
+    async def capture_audio(chunk):
+        enqueued_audio.append(chunk.copy())
+
+    processor._enqueue_active_audio = capture_audio
+
+    await processor._flush_remaining_pcm()
+
+    assert processor.total_pcm_samples == 110
+    assert processor.current_silence is None
+    assert len(processor.state.new_tokens) == 1
+    boundary = processor.state.new_tokens[0]
+    assert boundary.end == 1.05
+    assert boundary.duration == pytest.approx(0.65)
+    assert [len(chunk) for chunk in enqueued_audio] == [5]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pcm_tail", [b"", b"\x00"])
+async def test_eof_commits_active_pause_without_complete_pcm_sample(pcm_tail):
+    processor = _silence_processor(0.65)
+    processor.current_silence = Silence(start=0.3, is_starting=True)
+    processor.total_pcm_samples = 100
+    processor.bytes_per_sample = 2
+    processor.pcm_buffer = bytearray(pcm_tail)
+    processor.beg_loop = 1.0
+    processor.is_stopping = False
+    processor.is_pcm_input = True
+
+    await processor.process_audio(None)
+
+    assert processor.is_stopping is True
+    assert processor.current_silence is None
+    assert len(processor.state.new_tokens) == 1
+    boundary = processor.state.new_tokens[0]
+    assert boundary.end == 1.0
+    assert boundary.duration == pytest.approx(0.7)
+
+
+def _segmented_lines(diarization: bool):
+    first = ASRToken(0.0, 1.0, "first ")
+    pause = Silence(start=1.0, end=3.5, duration=2.5, has_ended=True)
+    second = ASRToken(3.5, 4.5, "second")
+    state = State(new_tokens=[first, pause, second])
+    if diarization:
+        state.new_diarization = [
+            SpeakerSegment(start=0.0, end=1.1, speaker=0),
+            SpeakerSegment(start=3.4, end=5.0, speaker=0),
+        ]
+    alignment = TokensAlignment(
+        state,
+        SimpleNamespace(diarization=diarization),
+        " ",
+    )
+    alignment.update()
+    first_refresh = alignment.get_lines(diarization=diarization, audio_time=4.5)[0]
+    alignment.update()
+    second_refresh = alignment.get_lines(diarization=diarization, audio_time=4.5)[0]
+    return (first, second), first_refresh, second_refresh
+
+
+@pytest.mark.parametrize("diarization", [False, True])
+def test_pause_creates_one_stable_boundary_without_changing_words(diarization):
+    tokens, first_refresh, second_refresh = _segmented_lines(diarization)
+
+    assert sum(line.is_silence() for line in first_refresh) == 1
+    assert sum(line.is_silence() for line in second_refresh) == 1
+    assert [line.is_silence() for line in second_refresh] == [False, True, False]
+    assert [line.to_dict() for line in first_refresh] == [line.to_dict() for line in second_refresh]
+    assert [token for line in second_refresh if not line.is_silence() for token in (line.tokens or [])] == list(tokens)
+    assert [
+        (token.start, token.end, token.text)
+        for line in second_refresh
+        if not line.is_silence()
+        for token in (line.tokens or [])
+    ] == [
+        (0.0, 1.0, "first "),
+        (3.5, 4.5, "second"),
+    ]
+    if diarization:
+        assert [line.speaker for line in second_refresh if not line.is_silence()] == [
+            1,
+            1,
+        ]
+
+
+def test_in_progress_pause_is_stable_in_full_and_diff_modes():
+    state = State(new_tokens=[ASRToken(0.0, 1.0, "speech")])
+    alignment = TokensAlignment(state, SimpleNamespace(diarization=False), " ")
+    tracker = DiffTracker()
+    reconstructed_lines = []
+    refreshes = []
+
+    for audio_time in (1.0, 3.1, 4.2):
+        alignment.update()
+        lines = alignment.get_lines(audio_time=audio_time)[0]
+        front_data = FrontData(status="active_transcription", lines=lines)
+        message = tracker.to_message(front_data)
+        reconstructed = reconstruct_state(message, reconstructed_lines)
+        assert reconstructed["lines"] == front_data.to_dict()["lines"]
+        refreshes.append((message, reconstructed))
+
+    pause = Silence(start=1.0, end=4.2, duration=3.2, has_ended=True)
+    state.new_tokens.append(pause)
+    alignment.update()
+    lines = alignment.get_lines(audio_time=4.2)[0]
+    front_data = FrontData(status="active_transcription", lines=lines)
+    message = tracker.to_message(front_data)
+    reconstructed = reconstruct_state(message, reconstructed_lines)
+
+    assert [len(item[1]["lines"]) for item in refreshes] == [1, 1, 1]
+    assert all("new_lines" not in item[0] for item in refreshes[1:])
+    assert reconstructed["lines"] == front_data.to_dict()["lines"]
+    assert len(reconstructed_lines) == 2
+    assert reconstructed_lines[-1]["speaker"] == -2
+    assert len(message["new_lines"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_full_mode_formatter_does_not_publish_in_progress_pause():
+    processor = object.__new__(AudioProcessor)
+    processor.args = SimpleNamespace(diarization=False)
+    processor.pause_segmentation_seconds = 2.0
+    processor.sample_rate = 100
+    processor.total_pcm_samples = 400
+    processor.current_silence = Silence(start=1.0, is_starting=True)
+    processor.state = State(new_tokens=[ASRToken(0.0, 1.0, "speech")])
+    processor.tokens_alignment = TokensAlignment(processor.state, processor.args, " ")
+    processor.translation = None
+    processor._ffmpeg_error = None
+    processor.last_response_content = FrontData()
+    processor.metrics = SessionMetrics()
+    processor.is_stopping = False
+
+    async def current_state():
+        return processor.state
+
+    processor.get_current_state = current_state
+    formatter = processor.results_formatter()
+
+    response = await anext(formatter)
+    await formatter.aclose()
+
+    assert [(line["speaker"], line["text"]) for line in response.to_dict()["lines"]] == [(1, "speech")]
+
+
+def test_diarization_lag_keeps_pause_behind_buffered_speech():
+    tokens = [
+        ASRToken(0.0, 0.5, "first "),
+        ASRToken(0.8, 1.3, "late-before "),
+        Silence(start=1.3, end=3.5, duration=2.2, has_ended=True),
+        ASRToken(3.5, 4.0, "after"),
+    ]
+    state = State(
+        new_tokens=tokens,
+        new_diarization=[SpeakerSegment(start=0.0, end=0.75, speaker=0)],
+    )
+    alignment = TokensAlignment(state, SimpleNamespace(diarization=True), " ")
+    alignment.update()
+
+    lines, buffer_text, _ = alignment.get_lines(diarization=True, audio_time=4.0)
+
+    assert [(line.speaker, line.text) for line in lines] == [(1, "first ")]
+    assert buffer_text == "late-before after"
+    assert not any(line.is_silence() for line in lines)
+
+    state.new_diarization = [SpeakerSegment(start=0.75, end=5.0, speaker=1)]
+    alignment.update()
+    lines, buffer_text, _ = alignment.get_lines(diarization=True, audio_time=5.0)
+
+    assert [(line.speaker, line.text) for line in lines] == [
+        (1, "first "),
+        (2, "late-before "),
+        (-2, None),
+        (2, "after"),
+    ]
+    assert buffer_text == ""
+    assert [token for line in lines if not line.is_silence() for token in (line.tokens or [])] == [
+        tokens[0],
+        tokens[1],
+        tokens[3],
+    ]

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -8,6 +8,7 @@ from typing import Any, AsyncGenerator, List, Optional, Union
 
 import numpy as np
 
+from whisperlivekit.config import validate_pause_segmentation_seconds
 from whisperlivekit.core import (
     TranscriptionEngine,
     online_diarization_factory,
@@ -104,6 +105,14 @@ class AudioProcessor:
 
         # Audio processing settings
         self.args = models.args
+        configured_pause_segmentation_seconds = getattr(
+            self.args,
+            "pause_segmentation_seconds",
+            MIN_DURATION_REAL_SILENCE,
+        )
+        self.pause_segmentation_seconds = validate_pause_segmentation_seconds(
+            configured_pause_segmentation_seconds
+        )
         self.sample_rate = 16000
         self.channels = 1
         chunk_seconds = self.args.vac_chunk_size if self.args.vac else self.args.min_chunk_size
@@ -280,7 +289,7 @@ class AudioProcessor:
             await self.transcription_queue.put(self.current_silence)
         if self.args.diarization and self.diarization_queue:
             await self.diarization_queue.put(self.current_silence)
-        if self.translation_queue:
+        if self.translation_queue and not self.transcription_queue:
             await self._flush_pending_translation_tokens()
             await self.translation_queue.put(self.current_silence)
 
@@ -301,9 +310,21 @@ class AudioProcessor:
             await self.transcription_queue.put(start_event)
         if self.args.diarization and self.diarization_queue:
             await self.diarization_queue.put(start_event)
-        if self.translation_queue:
+        if self.translation_queue and not self.transcription_queue:
             await self._flush_pending_translation_tokens()
             await self.translation_queue.put(start_event)
+
+    def _is_pause_segmentation_boundary(self, silence: Silence) -> bool:
+        """Whether a completed pause crosses the output threshold."""
+        threshold = getattr(
+            self,
+            "pause_segmentation_seconds",
+            MIN_DURATION_REAL_SILENCE,
+        )
+        if threshold <= 0 or silence.start is None:
+            return False
+        duration = silence.duration
+        return duration is not None and duration > threshold
 
     async def _end_silence(self, at_sample: Optional[int] = None) -> None:
         if not self.current_silence:
@@ -319,7 +340,12 @@ class AudioProcessor:
         self.metrics.n_silence_events += 1
         if self.current_silence.duration is not None:
             self.metrics.total_silence_duration_s += self.current_silence.duration
-        if self.current_silence.duration and self.current_silence.duration > MIN_DURATION_REAL_SILENCE:
+        if (
+            not self.transcription_queue
+            and self._is_pause_segmentation_boundary(self.current_silence)
+        ):
+            # With transcription enabled, the transcription queue publishes
+            # this marker after any words committed by the silence-start event.
             self.state.new_tokens.append(self.current_silence)
         # Push the completed silence as the end event (separate from the start event)
         await self._push_silence_event()
@@ -606,6 +632,7 @@ class AudioProcessor:
                 asr_processing_logs = f"internal_buffer={asr_internal_buffer_duration_s:.2f}s | lag={transcription_lag_s:.2f}s |"
                 stream_time_end_of_current_pcm = cumulative_pcm_duration_stream_time
                 new_tokens = []
+                segmentation_silence = None
                 current_audio_processed_upto = self.state.end_buffer
 
                 # Boundary handlers reset the processor, and on LocalAgreement a
@@ -634,6 +661,8 @@ class AudioProcessor:
                         cumulative_pcm_duration_stream_time += item.duration
                         current_audio_processed_upto = cumulative_pcm_duration_stream_time
                         self.transcription.end_silence(item.duration, self.state.tokens[-1].end if self.state.tokens else 0)
+                        if self._is_pause_segmentation_boundary(item):
+                            segmentation_silence = item
                     if self.state.tokens:
                         asr_processing_logs += f" | last_end = {self.state.tokens[-1].end} |"
                     logger.info(asr_processing_logs)
@@ -704,6 +733,8 @@ class AudioProcessor:
                             new_tokens[-1].end or 0.0,
                         )
                     self.state.new_tokens.extend(new_tokens)
+                    if segmentation_silence is not None:
+                        self.state.new_tokens.append(segmentation_silence)
                     self.state.new_tokens_buffer = _buffer_transcript
                     self._prune_state_tokens()
 
@@ -714,6 +745,13 @@ class AudioProcessor:
 
                 await self._queue_tokens_for_translation(new_tokens)
                 await self._queue_hypothesis_tail_for_translation(_buffer_transcript)
+                if isinstance(item, Silence) and self.translation_queue:
+                    # The silence-start ASR call can commit the final words of
+                    # the utterance. Forward those words before resetting the
+                    # translation boundary, then preserve the completed event.
+                    if item.is_starting:
+                        await self._flush_pending_translation_tokens()
+                    await self.translation_queue.put(item)
             except Exception as e:
                 logger.warning(f"Exception in transcription_processor: {e}")
                 logger.warning(f"Traceback: {traceback.format_exc()}")
@@ -833,11 +871,15 @@ class AudioProcessor:
                     continue
 
                 self.tokens_alignment.update()
+                audio_time = (
+                    self.total_pcm_samples / self.sample_rate
+                    if self.sample_rate
+                    else 0.0
+                )
                 lines, buffer_diarization_text, buffer_translation_text = self.tokens_alignment.get_lines(
                     diarization=self.args.diarization,
                     translation=bool(self.translation),
-                    current_silence=self.current_silence,
-                    audio_time=self.total_pcm_samples / self.sample_rate if self.sample_rate else None,
+                    audio_time=audio_time,
                 )
                 state = await self.get_current_state()
 
@@ -996,8 +1038,7 @@ class AudioProcessor:
 
             # Flush any remaining PCM data before signaling end-of-stream
             if self.is_pcm_input:
-                if self.pcm_buffer:
-                    await self._flush_remaining_pcm()
+                await self._flush_remaining_pcm()
                 await self._signal_input_complete()
             elif self.ffmpeg_manager:
                 await self.ffmpeg_manager.close_stdin()
@@ -1049,6 +1090,21 @@ class AudioProcessor:
         pcm_array = self.convert_pcm_to_float(self.pcm_buffer[:aligned_chunk_size])
         self.pcm_buffer = self.pcm_buffer[aligned_chunk_size:]
 
+        await self._process_pcm_array(pcm_array)
+
+        if not self.args.transcription and not self.args.diarization:
+            await asyncio.sleep(0.1)
+
+    async def _process_pcm_array(self, pcm_array: np.ndarray) -> None:
+        """Apply VAC segmentation to one PCM array and advance stream time."""
+        if pcm_array is None or pcm_array.size == 0:
+            return
+
+        # EOF can send a sub-chunk directly here. Without VAC, clear the
+        # initial placeholder before treating that tail as active speech.
+        if not self.args.vac and self.current_silence:
+            await self._end_silence(at_sample=self.total_pcm_samples)
+
         num_samples = len(pcm_array)
         chunk_sample_start = self.total_pcm_samples
         chunk_sample_end = chunk_sample_start + num_samples
@@ -1093,23 +1149,23 @@ class AudioProcessor:
 
         self.total_pcm_samples = chunk_sample_end
 
-        if not self.args.transcription and not self.args.diarization:
-            await asyncio.sleep(0.1)
+    async def _finalize_current_silence_at_stream_end(self) -> None:
+        """Commit a trailing pause at the final known stream position."""
+        if getattr(self, "current_silence", None):
+            await self._end_silence(at_sample=getattr(self, "total_pcm_samples", 0))
 
     async def _flush_remaining_pcm(self) -> None:
-        """Flush whatever PCM data remains in the buffer, regardless of size threshold."""
+        """Process the final PCM tail and commit any remaining pause."""
         if not self.pcm_buffer:
+            await self._finalize_current_silence_at_stream_end()
             return
         aligned_size = (len(self.pcm_buffer) // self.bytes_per_sample) * self.bytes_per_sample
         if aligned_size == 0:
+            await self._finalize_current_silence_at_stream_end()
             return
         pcm_array = self.convert_pcm_to_float(self.pcm_buffer[:aligned_size])
         self.pcm_buffer = self.pcm_buffer[aligned_size:]
 
-        # End any active silence so the audio gets enqueued
-        if self.current_silence:
-            await self._end_silence(at_sample=self.total_pcm_samples)
-
-        self.total_pcm_samples += len(pcm_array)
-        await self._enqueue_active_audio(pcm_array)
+        await self._process_pcm_array(pcm_array)
+        await self._finalize_current_silence_at_stream_end()
         logger.info(f"Flushed remaining PCM buffer: {len(pcm_array)} samples ({len(pcm_array)/self.sample_rate:.2f}s)")

--- a/whisperlivekit/config.py
+++ b/whisperlivekit/config.py
@@ -9,6 +9,21 @@ logger = logging.getLogger(__name__)
 FUNASR_LANGUAGES = frozenset({"auto", "zh", "yue", "en", "ja", "ko"})
 
 
+def validate_pause_segmentation_seconds(value: float) -> float:
+    """Return a normalized pause threshold or raise for invalid input."""
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "pause_segmentation_seconds must be finite and non-negative."
+        ) from exc
+    if not math.isfinite(normalized) or normalized < 0:
+        raise ValueError(
+            "pause_segmentation_seconds must be finite and non-negative."
+        )
+    return normalized
+
+
 def parse_cors_origins(origins: Optional[str]) -> list[str]:
     """Parse comma-separated CORS origins for FastAPI."""
     if origins is None:
@@ -160,7 +175,15 @@ class WhisperLiveKitConfig:
     canary_lid_min_sec: float = 2.0
     canary_lid_min_conf: float = 0.5
 
+    # Keep new fields at the end to preserve positional dataclass construction.
+    # Pauses longer than this become stable transcript boundaries; 0 disables.
+    pause_segmentation_seconds: float = 5.0
+
     def __post_init__(self):
+        self.pause_segmentation_seconds = validate_pause_segmentation_seconds(
+            self.pause_segmentation_seconds
+        )
+
         # .en model suffix forces English for Whisper-family backends.
         if (
             self.backend != "funasr"

--- a/whisperlivekit/parse_args.py
+++ b/whisperlivekit/parse_args.py
@@ -119,6 +119,17 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--pause-segmentation-seconds",
+        type=float,
+        default=5.0,
+        dest="pause_segmentation_seconds",
+        help=(
+            "Create a stable transcript boundary after a VAD pause longer than "
+            "this many seconds. Use 0 to disable pause-based segmentation."
+        ),
+    )
+
+    parser.add_argument(
         "--asr-coalesce-min-s",
         type=float,
         default=0.0,

--- a/whisperlivekit/tokens_alignment.py
+++ b/whisperlivekit/tokens_alignment.py
@@ -372,6 +372,11 @@ class TokensAlignment:
 
         for token in self.all_tokens:
             if token.is_silence():
+                # A boundary cannot overtake earlier speech that is still
+                # waiting for diarization. Keep the entire remaining suffix
+                # volatile until speaker coverage catches up.
+                if buffering_suffix:
+                    continue
                 flush_pending()
                 silence_segment = PuncSegment.from_tokens([token], is_silence=True)
                 if silence_segment is not None:


### PR DESCRIPTION
## Summary

- add `--pause-segmentation-seconds` with the historical 5 second default and `0` to disable
- commit exactly one stable silence boundary after a qualifying pause ends
- preserve ASR, translation, diarization, full-mode and diff-mode ordering
- process the final PCM tail through VAC before finalizing an EOF pause
- document the native behavior and the current Deepgram compatibility limits

## Validation

- 23 dedicated pause segmentation tests
- 201 passed, 13 skipped in the isolated suite outside the general pipeline file
- 13 passed in the real pipeline suite
- 4 passed in the real coalescing pipeline suite
- real custom thresholds at 0.5 and 2 seconds
- Ruff, lock check and diff check

Closes #409
