### PR TITLE
release: prepare 0.2.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "whisperlivekit"
-version = "0.2.25"
+version = "0.2.26"
 description = "Real-time speech-to-text models"
 readme = "README.md"
 authors = [{ name = "Quentin Fuxa" }]

--- a/uv.lock
+++ b/uv.lock
@@ -11074,7 +11074,7 @@ wheels = [
 
 [[package]]
 name = "whisperlivekit"
-version = "0.2.25"
+version = "0.2.26"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- bump the project version from 0.2.25 to 0.2.26
- update the root package entry in `uv.lock`
- leave all dependencies and package metadata otherwise unchanged

PyPI currently publishes 0.2.24. GitHub release v0.2.25 was never uploaded to PyPI, so 0.2.26 will be the next package release and will include every change since PyPI 0.2.24.

This PR does not upload a package, create a tag, or publish a GitHub release. The PyPI Trusted Publisher must be registered before the manual publication workflow is dispatched.

## Validation

- diff is exactly the two version replacements
- `uv lock --check` passes
- fresh `uv build --no-sources` produces only the expected 0.2.26 sdist and wheel
- `twine check` passes
- package metadata reports version 0.2.26, Apache-2.0, and Python 3.11 through 3.13
- wheel installs in an isolated environment and reports 0.2.26 through `importlib.metadata`
- wheel RECORD hashes and archive paths are valid
- Sortformer fixtures and their CC BY 4.0 attribution are present only in the sdist
- PyPI's 0.2.26 JSON endpoint returns 404