### PR TITLE
Fix Deepgram streaming semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ wlk bench
 
 #### API Compatibility
 
-WhisperLiveKit exposes multiple APIs so you can use it as a drop-in replacement:
+WhisperLiveKit exposes compatibility-oriented subsets of popular APIs:
 
 ```bash
 # OpenAI-compatible REST API
@@ -82,8 +82,8 @@ curl http://localhost:8000/v1/audio/transcriptions -F file=@audio.wav
 # Works with the OpenAI Python SDK
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
 
-# Deepgram-compatible WebSocket (use any Deepgram SDK)
-# Just point your Deepgram client at localhost:8000
+# Deepgram-compatible WebSocket
+# See docs/API.md for supported options and current SDK setup
 
 # Native WebSocket for real-time streaming
 ws://localhost:8000/asr

--- a/docs/API.md
+++ b/docs/API.md
@@ -120,44 +120,91 @@ curl http://localhost:8000/health
 ### WS /v1/listen
 
 Compatibility-oriented subset of Deepgram's Live Transcription WebSocket.
-Current Deepgram client SDKs can connect when they use only the parameters and
-messages documented below.
+The adapter is verified with `deepgram-sdk==7.7.0`. Install that version and use
+only the parameters and messages documented below.
+
+```bash
+pip install deepgram-sdk==7.7.0
+```
 
 ```python
-from deepgram import DeepgramClient, LiveOptions
+from deepgram import AsyncDeepgramClient
+from deepgram.environment import DeepgramClientEnvironment
 
-deepgram = DeepgramClient(api_key="unused", config={"url": "localhost:8000"})
-connection = deepgram.listen.websocket.v("1")
-connection.start(LiveOptions(model="nova-2", language="en"))
+environment = DeepgramClientEnvironment(
+    base="http://localhost:8000",
+    production="ws://localhost:8000",
+    agent="ws://localhost:8000",
+    agent_rest="http://localhost:8000",
+)
+# Use the WLK API token here when the server was started with --api-token.
+deepgram = AsyncDeepgramClient(api_key="unused", environment=environment)
+
+async with deepgram.listen.v1.connect(
+    model="nova-3",
+    language="en",
+    encoding="linear16",
+    sample_rate=16000,
+    channels=1,
+    interim_results=True,
+    endpointing=300,
+    utterance_end_ms=1000,
+    vad_events=True,
+) as connection:
+    await connection.send_media(pcm_audio)
+    message = await connection.recv()
+    await connection.send_close_stream()
 ```
 
 **Supported Query Parameters:**
 
 - `language`: per-session source language
-- `vad_events=true`: emit `SpeechStarted` events
+- `model`: accepted for SDK compatibility; the server's configured WLK backend
+  remains authoritative
+- `encoding=linear16`: select raw signed 16-bit PCM input; requires
+  `sample_rate=16000`
+- `sample_rate=16000`: WLK's fixed input sample rate for raw PCM
+- `channels=1`: mono input; this is the only supported channel count
+- `interim_results=true|false`: emit revisable `is_final=false` hypotheses;
+  defaults to `false`
+- `endpointing=false|N`: disable pause endpoints or set a positive silence
+  threshold in milliseconds; defaults to 10 ms
+- `utterance_end_ms=N`: enable the independent finalized-word gap detector;
+  requires `interim_results=true` and accepts integers from 1000 to 5000
+- `vad_events=true|false`: emit `SpeechStarted` on VAD speech transitions;
+  defaults to `false`
 
-Deepgram's `endpointing` and `utterance_end_ms` parameters are not implemented and
-do not control `--pause-segmentation-seconds`. WhisperLiveKit currently marks every
-committed `Results` message as `speech_final` and emits its existing
-`UtteranceEnd` event from VAD-derived silence lines. These are compatibility
-approximations, not Deepgram's separate endpointing and word-gap timers.
+Numeric endpointing and `vad_events=true` require the server's VAC to be enabled.
+Endpointing uses submitted audio timestamps, not wall-clock time, and is
+independent from `--pause-segmentation-seconds`. A pause endpoint emits
+`speech_final=true` once. `UtteranceEnd` uses its own timer after the last word of
+a final result and is deduplicated for that word timestamp.
 
 **Client Messages:**
 - Binary audio frames
-- `{"type": "KeepAlive"}` — keep connection alive
-- `{"type": "CloseStream"}` — graceful close
-- `{"type": "Finalize"}` — flush pending audio
+- `{"type": "KeepAlive"}`: keep the connection alive without advancing audio time
+- `{"type": "CloseStream"}`: drain pending audio, receive final Results and
+  summary Metadata, then close
+
+Deepgram's non-terminal `Finalize` control is rejected explicitly. WLK backends
+currently expose only a terminal flush, so accepting more audio afterward would
+silently lose it. Send `CloseStream` when the audio is complete. An empty binary
+frame is also rejected and is not treated as EOF.
 
 **Server Messages:**
-- `Metadata` — sent once at connection start
-- `Results` — transcription results with `is_final`/`speech_final` flags
-- `UtteranceEnd` — silence detected after speech
-- `SpeechStarted` — speech begins (requires `vad_events=true`)
+- `Metadata`: request metadata and the final stream summary
+- `Results`: revisable or immutable transcript ranges with independent
+  `is_final` and `speech_final` flags
+- `UtteranceEnd`: finalized-word gap reached when configured
+- `SpeechStarted`: VAD speech begins when `vad_events=true`
 
 **Limitations vs Deepgram:**
-- No authentication (self-hosted)
-- Word timestamps are interpolated from segment boundaries
+- Self-hosted authentication uses the optional WLK API token rather than a
+  Deepgram project key
+- Native ASR token timestamps are preserved when available; multi-word source
+  tokens fall back to interpolation within their token span
 - Confidence scores are 0.0 (not available)
+- `Finalize` and channel-specific finalization are not supported
 
 ---
 
@@ -603,8 +650,8 @@ with and without diarization. Use `--pause-segmentation-seconds 0` to disable th
 boundaries. The boundary is committed after the pause ends, when speech resumes
 or end of input is received; an in-progress pause is not added to `lines`. The
 native `/asr` WebSocket uses the server-wide setting. The
-Deepgram-compatible `/v1/listen` endpoint uses the same server-wide setting;
-Deepgram's `endpointing` query parameter is not mapped to it.
+Deepgram-compatible `/v1/listen` endpoint instead keeps its per-session
+`endpointing` timer separate from these native output lines.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7.0", "pytest-asyncio>=0.21", "datasets>=2.14", "librosa"]
+test = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "datasets>=2.14",
+    "librosa",
+    "deepgram-sdk==7.7.0",
+]
 translation = ["nllw"]
 sentence_tokenizer = ["mosestokenizer", "wtpsplit"]
 funasr = ["funasr~=1.4.1"]

--- a/tests/test_deepgram_compat.py
+++ b/tests/test_deepgram_compat.py
@@ -1,0 +1,1576 @@
+"""Deepgram protocol regressions for issue #413."""
+
+import asyncio
+import unicodedata
+from types import SimpleNamespace
+
+import pytest
+
+from whisperlivekit.deepgram_compat import (
+    DeepgramAdapter,
+    DeepgramOptions,
+    handle_deepgram_websocket,
+)
+from whisperlivekit.timed_objects import (
+    ASRToken,
+    AudioStreamEvent,
+    FrontData,
+    Segment,
+    Silence,
+)
+
+
+class RecordingWebSocket:
+    def __init__(self, query_params=None, incoming=None, headers=None):
+        self.query_params = query_params or {}
+        self.headers = headers or {}
+        self.incoming = asyncio.Queue()
+        for message in incoming or []:
+            self.incoming.put_nowait(message)
+        self.sent = []
+        self.accepted = False
+        self.closed = None
+
+    async def accept(self):
+        self.accepted = True
+
+    async def send_json(self, message):
+        self.sent.append(message)
+
+    async def receive(self):
+        return await self.incoming.get()
+
+    async def close(self, code=1000, reason=None):
+        self.closed = (code, reason)
+
+
+def _options(**overrides):
+    values = {
+        "language": None,
+        "interim_results": True,
+        "vad_events": False,
+        "endpointing_ms": 300,
+        "utterance_end_ms": None,
+        "pcm_input": None,
+    }
+    values.update(overrides)
+    return DeepgramOptions(**values)
+
+
+def _token(start, end, text):
+    return ASRToken(start=start, end=end, text=text)
+
+
+def _speech_line(*tokens, speaker=-1):
+    line = Segment.from_tokens(list(tokens))
+    line.speaker = speaker
+    return line
+
+
+def _results(websocket, *, final=None):
+    messages = [message for message in websocket.sent if message.get("type") == "Results"]
+    if final is None:
+        return messages
+    return [message for message in messages if message["is_final"] is final]
+
+
+def _transcript(message):
+    return message["channel"]["alternatives"][0]["transcript"]
+
+
+@pytest.mark.parametrize(
+    ("params", "expected"),
+    [
+        ({}, (False, False, 10, None)),
+        (
+            {
+                "interim_results": "true",
+                "vad_events": "true",
+                "endpointing": "450",
+                "utterance_end_ms": "1200",
+            },
+            (True, True, 450, 1200),
+        ),
+        ({"endpointing": "false"}, (False, False, None, None)),
+        ({"endpointing": "true"}, (False, False, 10, None)),
+    ],
+)
+def test_deepgram_options_parse_supported_values(params, expected):
+    options = DeepgramOptions.from_query_params(params, vac_enabled=True)
+
+    assert (
+        options.interim_results,
+        options.vad_events,
+        options.endpointing_ms,
+        options.utterance_end_ms,
+    ) == expected
+
+
+def test_linear16_options_select_exact_pcm_contract():
+    options = DeepgramOptions.from_query_params(
+        {
+            "encoding": "linear16",
+            "sample_rate": "16000",
+            "channels": "1",
+        },
+        vac_enabled=True,
+    )
+
+    assert options.pcm_input is True
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"interim_results": "yes"}, "interim_results must be true or false"),
+        ({"vad_events": "1"}, "vad_events must be true or false"),
+        ({"endpointing": "0"}, "endpointing must be greater than zero"),
+        ({"endpointing": "-1"}, "endpointing must be an integer"),
+        ({"endpointing": "1.5"}, "endpointing must be an integer"),
+        ({"utterance_end_ms": "999", "interim_results": "true"}, "between 1000 and 5000"),
+        ({"utterance_end_ms": "5001", "interim_results": "true"}, "between 1000 and 5000"),
+        ({"utterance_end_ms": "1000"}, "requires interim_results=true"),
+        ({"encoding": "mulaw"}, "encoding must be linear16"),
+        ({"encoding": "linear16"}, "sample_rate=16000 is required"),
+        (
+            {"encoding": "linear16", "sample_rate": "8000"},
+            "supports sample_rate=16000 only",
+        ),
+        ({"channels": "2"}, "supports channels=1 only"),
+    ],
+)
+def test_deepgram_options_reject_invalid_values(params, message):
+    with pytest.raises(ValueError, match=message):
+        DeepgramOptions.from_query_params(params, vac_enabled=True)
+
+
+def test_deepgram_options_require_vac_for_endpointing():
+    with pytest.raises(ValueError, match="endpointing requires VAC"):
+        DeepgramOptions.from_query_params({}, vac_enabled=False)
+
+    options = DeepgramOptions.from_query_params(
+        {"endpointing": "false"},
+        vac_enabled=False,
+    )
+    assert options.endpointing_ms is None
+
+    with pytest.raises(ValueError, match="vad_events requires VAC"):
+        DeepgramOptions.from_query_params(
+            {"endpointing": "false", "vad_events": "true"},
+            vac_enabled=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("query", "header", "expected"),
+    [
+        ({"token": "query-secret"}, "", "query-secret"),
+        ({}, "Token sdk-secret", "sdk-secret"),
+        ({}, "Bearer bearer-secret", "bearer-secret"),
+        ({}, "Basic ignored", None),
+    ],
+)
+def test_websocket_auth_accepts_wlk_and_deepgram_token_styles(
+    query,
+    header,
+    expected,
+):
+    from whisperlivekit.api_auth import websocket_token
+
+    websocket = RecordingWebSocket(
+        query,
+        headers={"authorization": header},
+    )
+    assert websocket_token(websocket) == expected
+
+
+@pytest.mark.asyncio
+async def test_line_growth_and_pause_emit_every_word_once():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options())
+    hello = _token(0.1, 0.5, "hello")
+    world = _token(0.6, 0.9, "world")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(hello)]))
+    await adapter.process_update(FrontData(lines=[_speech_line(hello, world)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.9))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.9)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.199))
+
+    assert [_transcript(message) for message in _results(websocket, final=True)] == ["hello"]
+    assert not any(message["speech_final"] for message in _results(websocket, final=True))
+
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.2))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 2.0))
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["hello", "world"]
+    assert [message["speech_final"] for message in finals] == [False, True]
+    assert " ".join(filter(None, map(_transcript, finals))) == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_mutable_suffix_replacement_never_publishes_retracted_word():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options())
+    hello = _token(0.0, 0.4, "hello")
+    world = _token(0.4, 0.8, "world")
+    there = _token(0.4, 0.85, "there")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(hello, world)]))
+    await adapter.process_update(FrontData(lines=[_speech_line(hello, there)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.9))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.9)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.2))
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["hello", "there"]
+    assert all("world" not in _transcript(message) for message in finals)
+
+
+@pytest.mark.asyncio
+async def test_split_and_merge_lines_do_not_duplicate_tokens():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=None))
+    one = _token(0.0, 0.3, "go")
+    two = _token(0.3, 0.6, "go")
+    three = _token(0.6, 0.9, "now")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(one, two)]))
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(one, speaker=1), _speech_line(two, speaker=2)])
+    )
+    await adapter.process_update(FrontData(lines=[_speech_line(one, two, three)]))
+    await adapter.finish_stream(1.0)
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["go go", "now"]
+    assert " ".join(map(_transcript, finals)) == "go go now"
+
+
+@pytest.mark.asyncio
+async def test_interim_revises_speaker_and_time_without_duplicating_final_text():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=None))
+    first = _token(0.0, 0.4, "hello")
+    revised = _token(0.05, 0.45, "hello")
+
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(first, speaker=1)])
+    )
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(revised, speaker=2)])
+    )
+
+    interims = _results(websocket, final=False)
+    assert len(interims) == 2
+    first_word = interims[0]["channel"]["alternatives"][0]["words"][0]
+    revised_word = interims[1]["channel"]["alternatives"][0]["words"][0]
+    assert (first_word["speaker"], first_word["start"], first_word["end"]) == (
+        0,
+        0.0,
+        0.4,
+    )
+    assert (
+        revised_word["speaker"],
+        revised_word["start"],
+        revised_word["end"],
+    ) == (1, 0.05, 0.45)
+
+    await adapter.finish_stream(0.5)
+    assert [_transcript(message) for message in _results(websocket, final=True)] == [
+        "hello"
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("parts", "expected"),
+    [
+        (["Hello", ",", " world", "!"], "Hello, world!"),
+        (["“", "Hello", "”"], "“Hello”"),
+        (["你", "好", "，", "世界"], "你好，世界"),
+    ],
+)
+async def test_transcript_preserves_source_spacing_and_punctuation(parts, expected):
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=None))
+    tokens = [
+        _token(index * 0.1, (index + 1) * 0.1, text)
+        for index, text in enumerate(parts)
+    ]
+
+    await adapter.process_update(FrontData(lines=[_speech_line(*tokens)]))
+    await adapter.finish_stream(len(parts) * 0.1)
+
+    result = _results(websocket, final=True)[0]
+    assert _transcript(result) == expected
+    words = result["channel"]["alternatives"][0]["words"]
+    assert all("_source_text" not in word for word in words)
+    assert all(
+        not all(
+            unicodedata.category(character).startswith("P")
+            for character in word["word"]
+        )
+        for word in words
+    )
+    if expected == "Hello, world!":
+        assert [(word["word"], word["punctuated_word"]) for word in words] == [
+            ("Hello", "Hello,"),
+            ("world", "world!"),
+        ]
+    if expected == "“Hello”":
+        assert [(word["word"], word["punctuated_word"]) for word in words] == [
+            ("Hello", "“Hello”"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_late_terminal_punctuation_is_emitted_once_after_final_word():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=100))
+    hello = _token(0.0, 0.4, "hello")
+    comma = _token(0.4, 0.45, ",")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(hello)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.4))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.4)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.5))
+    await adapter.process_update(FrontData(lines=[_speech_line(hello, comma)]))
+    await adapter.process_update(FrontData(lines=[_speech_line(hello, comma)]))
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["hello", ","]
+    assert finals[0]["speech_final"] is True
+    assert finals[1]["speech_final"] is False
+    assert finals[1]["channel"]["alternatives"][0]["words"] == []
+
+
+@pytest.mark.asyncio
+async def test_snapshot_shrink_cannot_delete_or_crash_below_final_cursor():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=None))
+    one = _token(0.0, 0.2, "one")
+    two = _token(0.2, 0.4, "two")
+    three = _token(0.4, 0.6, "three")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(one, two)]))
+    await adapter.process_update(FrontData(lines=[_speech_line(one, two, three)]))
+    await adapter.process_update(FrontData(lines=[_speech_line(one)]))
+    await adapter.finish_stream(0.6)
+
+    assert [_transcript(message) for message in _results(websocket, final=True)] == [
+        "one two"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_endpointing_false_never_marks_pause_speech_final():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=None))
+    hello = _token(0.0, 0.5, "hello")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(hello)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 5.0))
+
+    assert not _results(websocket, final=True)
+
+    await adapter.finish_stream(5.0)
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["hello"]
+    assert finals[0]["speech_final"] is False
+
+
+@pytest.mark.asyncio
+async def test_interim_option_gates_revisions_and_close_freezes_buffer():
+    disabled_socket = RecordingWebSocket()
+    disabled = DeepgramAdapter(
+        disabled_socket,
+        _options(interim_results=False, endpointing_ms=None),
+    )
+    await disabled.process_update(FrontData(buffer_transcription="hello"))
+    assert not _results(disabled_socket)
+    await disabled.finish_stream(0.5)
+    assert [_transcript(message) for message in _results(disabled_socket)] == ["hello"]
+    assert _results(disabled_socket)[0]["is_final"] is True
+
+    enabled_socket = RecordingWebSocket()
+    enabled = DeepgramAdapter(
+        enabled_socket,
+        _options(interim_results=True, endpointing_ms=None),
+    )
+    await enabled.process_update(FrontData(buffer_transcription="hello"))
+    await enabled.process_update(FrontData(buffer_transcription="hello world"))
+    await enabled.process_update(FrontData(buffer_transcription="hello world"))
+    assert [_transcript(message) for message in _results(enabled_socket)] == [
+        "hello",
+        "hello world",
+    ]
+    assert all(not message["is_final"] for message in _results(enabled_socket))
+
+
+@pytest.mark.asyncio
+async def test_diarization_and_asr_buffers_are_visible_and_frozen_at_close():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(interim_results=True, endpointing_ms=None),
+    )
+
+    await adapter.process_update(
+        FrontData(
+            buffer_diarization="waiting for speaker",
+            buffer_transcription="and ASR",
+        )
+    )
+    assert [_transcript(message) for message in _results(websocket)] == [
+        "waiting for speaker and ASR"
+    ]
+
+    await adapter.finish_stream(1.0)
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == [
+        "waiting for speaker and ASR"
+    ]
+    assert finals[0]["channel"]["alternatives"][0]["words"] == []
+
+
+@pytest.mark.asyncio
+async def test_serialized_diarization_buffer_is_not_dropped():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(interim_results=False, endpointing_ms=None),
+    )
+
+    await adapter.process_update(
+        {
+            "lines": [],
+            "buffer_diarization": "late diarization",
+            "buffer_transcription": "tail",
+        }
+    )
+    await adapter.finish_stream(1.0)
+
+    assert [_transcript(message) for message in _results(websocket, final=True)] == [
+        "late diarization tail"
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("line_text", "diarization_buffer", "asr_buffer", "expected"),
+    [
+        ("你", "", "好", "你好"),
+        ("Hello", "", ",", "Hello,"),
+        ("", "你", "好", "你好"),
+        ("", "Hello", "world", "Hello world"),
+    ],
+)
+async def test_buffer_boundaries_preserve_language_appropriate_spacing(
+    line_text,
+    diarization_buffer,
+    asr_buffer,
+    expected,
+):
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(interim_results=True, endpointing_ms=None),
+    )
+    lines = []
+    if line_text:
+        lines.append(_speech_line(_token(0.0, 0.2, line_text)))
+
+    await adapter.process_update(
+        FrontData(
+            lines=lines,
+            buffer_diarization=diarization_buffer,
+            buffer_transcription=asr_buffer,
+        )
+    )
+
+    assert [_transcript(message) for message in _results(websocket, final=False)] == [
+        expected
+    ]
+
+
+@pytest.mark.asyncio
+async def test_final_word_timestamps_are_frozen_across_later_growth():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=None))
+    first_hello = _token(0.0, 0.4, "hello")
+    revised_hello = _token(0.0, 0.5, "hello")
+    world = _token(0.5, 0.8, "world")
+    again = _token(0.8, 1.1, "again")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(first_hello)]))
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(revised_hello, world)])
+    )
+    first_final = _results(websocket, final=True)[0]
+    assert first_final["channel"]["alternatives"][0]["words"][0]["end"] == 0.5
+
+    revised_again = _token(0.0, 0.7, "hello")
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(revised_again, world, again)])
+    )
+    assert first_final["channel"]["alternatives"][0]["words"][0]["end"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_short_pause_is_cancelled_before_endpoint_threshold():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=300))
+    hello = _token(0.0, 0.5, "hello")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(hello)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.75))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 0.75))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 2.0))
+
+    assert not any(message["speech_final"] for message in _results(websocket, final=True))
+
+
+@pytest.mark.asyncio
+async def test_short_or_disabled_endpoint_does_not_delay_vad_speech_started():
+    for endpointing_ms in (300, None):
+        websocket = RecordingWebSocket()
+        adapter = DeepgramAdapter(
+            websocket,
+            _options(endpointing_ms=endpointing_ms, vad_events=True),
+        )
+        await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+        await adapter.process_stream_event(AudioStreamEvent("speech_started", 0.7))
+
+        assert [
+            message
+            for message in websocket.sent
+            if message.get("type") == "SpeechStarted"
+        ] == [{"type": "SpeechStarted", "channel": [0, 1], "timestamp": 0.7}]
+
+
+@pytest.mark.asyncio
+async def test_long_completed_pause_waits_for_late_transcription_barrier():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(endpointing_ms=300, vad_events=True),
+    )
+    hello = _token(0.0, 0.5, "hello")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(hello)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.9))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.0))
+    assert not _results(websocket, final=True)
+
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["hello"]
+    assert finals[0]["speech_final"] is True
+    assert [
+        message for message in websocket.sent if message.get("type") == "SpeechStarted"
+    ] == [{"type": "SpeechStarted", "channel": [0, 1], "timestamp": 1.0}]
+
+
+@pytest.mark.asyncio
+async def test_endpoint_waits_for_final_diarization_speaker():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=300))
+    hello = _token(0.0, 0.5, "hello")
+
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(hello, speaker=1)],
+            remaining_time_diarization=0.4,
+        )
+    )
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.8))
+    assert not _results(websocket, final=True)
+
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(hello, speaker=2)],
+            remaining_time_diarization=0.0,
+        )
+    )
+
+    final = _results(websocket, final=True)[0]
+    assert _transcript(final) == "hello"
+    assert final["speech_final"] is True
+    assert final["channel"]["alternatives"][0]["words"][0]["speaker"] == 1
+
+
+@pytest.mark.asyncio
+async def test_line_growth_cannot_freeze_speakers_while_diarization_lags():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=300))
+    hello = _token(0.0, 0.5, "hello")
+    world = _token(0.5, 0.9, "world")
+
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(hello, speaker=1)],
+            remaining_time_diarization=0.4,
+        )
+    )
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(hello, world, speaker=1)],
+            remaining_time_diarization=0.4,
+        )
+    )
+    assert not _results(websocket, final=True)
+
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.9))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.9)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.2))
+    await adapter.process_update(
+        FrontData(
+            lines=[
+                _speech_line(hello, speaker=2),
+                _speech_line(world, speaker=3),
+            ],
+            remaining_time_diarization=0.0,
+        )
+    )
+
+    final = _results(websocket, final=True)[0]
+    words = final["channel"]["alternatives"][0]["words"]
+    assert [_transcript(final)] == ["hello world"]
+    assert [word["speaker"] for word in words] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_silence_boundary_waits_for_final_diarization_speaker():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=None))
+    hello = _token(0.0, 0.5, "hello")
+    silence = Silence(start=0.5, end=1.0)
+
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(hello, speaker=1), silence],
+            remaining_time_diarization=0.4,
+        )
+    )
+    assert not _results(websocket, final=True)
+
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(hello, speaker=2), silence],
+            remaining_time_diarization=0.0,
+        )
+    )
+
+    final = _results(websocket, final=True)[0]
+    assert _transcript(final) == "hello"
+    assert final["speech_final"] is False
+    assert final["channel"]["alternatives"][0]["words"][0]["speaker"] == 1
+
+
+@pytest.mark.asyncio
+async def test_two_delayed_pause_barriers_keep_distinct_endpoints_and_starts():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(endpointing_ms=300, vad_events=True),
+    )
+    one = _token(0.0, 0.5, "one")
+    two = _token(1.0, 1.5, "two")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(one)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.9))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.0))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 1.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.9))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 2.0))
+
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+    await adapter.process_update(FrontData(lines=[_speech_line(one, two)]))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 1.5)
+    )
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["one", "two"]
+    assert [message["speech_final"] for message in finals] == [True, True]
+    speech_started = [
+        message for message in websocket.sent if message.get("type") == "SpeechStarted"
+    ]
+    assert [message["timestamp"] for message in speech_started] == [1.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_diarization_lag_keeps_two_pause_prefixes_distinct():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(endpointing_ms=300, vad_events=True),
+    )
+    one = _token(0.0, 0.5, "one")
+    two = _token(1.0, 1.5, "two")
+
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(one, speaker=1)],
+            remaining_time_diarization=0.4,
+        )
+    )
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.9))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.0))
+
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(one, two, speaker=1)],
+            remaining_time_diarization=0.4,
+        )
+    )
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 1.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.9))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 1.5)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 2.0))
+    assert not _results(websocket, final=True)
+
+    await adapter.process_update(
+        FrontData(
+            lines=[
+                _speech_line(one, speaker=2),
+                _speech_line(two, speaker=3),
+            ],
+            remaining_time_diarization=0.0,
+        )
+    )
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["one", "two"]
+    assert [message["speech_final"] for message in finals] == [True, True]
+    assert [
+        message["channel"]["alternatives"][0]["words"][0]["speaker"]
+        for message in finals
+    ] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_later_ready_pause_cannot_finalize_an_earlier_unready_pause():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=300))
+    one = _token(0.0, 0.5, "one")
+    two = _token(1.0, 1.5, "two")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(one)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.9))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.0))
+    await adapter.process_update(FrontData(lines=[_speech_line(one, two)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 1.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.9))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 1.5)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 2.0))
+    assert not _results(websocket, final=True)
+
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["one", "two"]
+    assert all(message["speech_final"] is True for message in finals)
+
+
+@pytest.mark.asyncio
+async def test_short_later_pause_cannot_reorder_speech_started_events():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(endpointing_ms=300, vad_events=True),
+    )
+    one = _token(0.0, 0.5, "one")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(one)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.9))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.0))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 1.5))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.7))
+    assert not [
+        message
+        for message in websocket.sent
+        if message.get("type") == "SpeechStarted"
+    ]
+
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+
+    speech_started = [
+        message
+        for message in websocket.sent
+        if message.get("type") == "SpeechStarted"
+    ]
+    assert [message["timestamp"] for message in speech_started] == [1.0, 1.7]
+
+
+@pytest.mark.asyncio
+async def test_pending_buffer_cannot_move_endpoint_into_later_words():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(endpointing_ms=300))
+    one = _token(0.0, 0.5, "one")
+    two = _token(1.0, 1.5, "two")
+    three = _token(1.5, 2.0, "three")
+
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(one)], buffer_transcription="pending")
+    )
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.9))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.0))
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(one, two)],
+            buffer_transcription="pending",
+        )
+    )
+    await adapter.process_update(
+        FrontData(
+            lines=[_speech_line(one, two, three)],
+            buffer_transcription="pending",
+        )
+    )
+    assert not _results(websocket, final=True)
+
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(one, two, three)])
+    )
+    await adapter.finish_stream(2.0)
+
+    finals = _results(websocket, final=True)
+    assert [_transcript(message) for message in finals] == ["one", "two three"]
+    assert [message["speech_final"] for message in finals] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_utterance_end_has_an_independent_deduplicated_word_gap_timer():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(endpointing_ms=None, utterance_end_ms=1000),
+    )
+    hello = _token(0.0, 0.5, "hello")
+    later = _token(2.0, 2.4, "later")
+
+    await adapter.process_update(FrontData(lines=[_speech_line(hello)]))
+    await adapter.process_update(FrontData(lines=[_speech_line(hello, later)]))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.499))
+    assert not [message for message in websocket.sent if message.get("type") == "UtteranceEnd"]
+
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 1.5))
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 2.5))
+
+    events = [message for message in websocket.sent if message.get("type") == "UtteranceEnd"]
+    assert events == [
+        {
+            "type": "UtteranceEnd",
+            "channel": [0, 1],
+            "last_word_end": 0.5,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_late_final_rechecks_utterance_end_against_current_audio_clock():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(endpointing_ms=None, utterance_end_ms=1000),
+    )
+    hello = _token(0.0, 0.5, "hello")
+    later = _token(3.1, 3.5, "later")
+
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 3.0))
+    await adapter.process_update(FrontData(lines=[_speech_line(hello)]))
+    await adapter.process_update(FrontData(lines=[_speech_line(hello, later)]))
+
+    final_and_gap = [
+        message
+        for message in websocket.sent
+        if message.get("type") == "UtteranceEnd"
+        or (message.get("type") == "Results" and message["is_final"])
+    ]
+    assert [message["type"] for message in final_and_gap] == [
+        "Results",
+        "UtteranceEnd",
+    ]
+    assert final_and_gap[-1]["last_word_end"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_gap_inside_one_final_result_does_not_emit_utterance_end():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(endpointing_ms=None, utterance_end_ms=1000),
+    )
+    words = [_token(0.0, 0.5, "hello"), _token(2.0, 2.4, "again")]
+
+    await adapter.process_update(FrontData(lines=[_speech_line(*words)]))
+    await adapter.finish_stream(3.0)
+
+    assert not [message for message in websocket.sent if message.get("type") == "UtteranceEnd"]
+
+
+@pytest.mark.asyncio
+async def test_speech_started_uses_vad_timestamp_and_deepgram_channel_field():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(vad_events=True))
+
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.25))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 1.30))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 2.0))
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 2.4))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 2.0)
+    )
+
+    events = [message for message in websocket.sent if message.get("type") == "SpeechStarted"]
+    assert events == [
+        {"type": "SpeechStarted", "channel": [0, 1], "timestamp": 1.25},
+        {"type": "SpeechStarted", "channel": [0, 1], "timestamp": 2.4},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_results_never_replace_authoritative_vad_speech_timestamp():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(vad_events=True, endpointing_ms=None),
+    )
+
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(_token(0.15, 0.5, "hello"))])
+    )
+    assert not [
+        message for message in websocket.sent if message.get("type") == "SpeechStarted"
+    ]
+
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 0.08))
+    assert [
+        message for message in websocket.sent if message.get("type") == "SpeechStarted"
+    ] == [{"type": "SpeechStarted", "channel": [0, 1], "timestamp": 0.08}]
+
+
+@pytest.mark.asyncio
+async def test_endpoint_flush_does_not_invent_a_second_speech_started():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(websocket, _options(vad_events=True))
+    hello = _token(0.0, 0.5, "hello")
+
+    await adapter.process_stream_event(AudioStreamEvent("speech_started", 0.0))
+    await adapter.process_update(FrontData(lines=[_speech_line(hello)]))
+    await adapter.process_stream_event(AudioStreamEvent("silence_started", 0.5))
+    await adapter.process_stream_event(
+        AudioStreamEvent("silence_transcription_ready", 0.5)
+    )
+    await adapter.process_stream_event(AudioStreamEvent("audio_advanced", 0.8))
+
+    events = [message for message in websocket.sent if message.get("type") == "SpeechStarted"]
+    assert events == [
+        {"type": "SpeechStarted", "channel": [0, 1], "timestamp": 0.0}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_metadata_and_results_include_current_sdk_fields():
+    websocket = RecordingWebSocket()
+    adapter = DeepgramAdapter(
+        websocket,
+        _options(endpointing_ms=None),
+        SimpleNamespace(backend="faster-whisper"),
+    )
+
+    await adapter.send_metadata()
+    await adapter.process_update(
+        FrontData(lines=[_speech_line(_token(0.0, 0.5, "hello"))])
+    )
+    await adapter.finish_stream(0.5)
+    await adapter.send_summary_metadata(0.5)
+
+    initial, summary = [message for message in websocket.sent if message["type"] == "Metadata"]
+    assert initial["transaction_key"] == "deprecated"
+    assert summary["duration"] == 0.5
+    result = _results(websocket, final=True)[0]
+    assert result["metadata"]["request_id"] == adapter.request_id
+    assert result["metadata"]["model_info"]["name"] == "faster-whisper"
+    assert result["metadata"]["model_uuid"] == adapter.model_uuid
+
+
+class DelayedFinalProcessor:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.total_pcm_samples = 8000
+        self.sample_rate = 16000
+        self.stop = asyncio.Event()
+        self.cleanup_called = False
+        self.create_tasks_calls = 0
+        self.processed = []
+        type(self).instances.append(self)
+
+    async def create_tasks(self):
+        self.create_tasks_calls += 1
+
+        async def results():
+            await self.stop.wait()
+            await asyncio.sleep(0)
+            yield FrontData(
+                lines=[_speech_line(_token(0.0, 0.5, "tail"))]
+            )
+
+        return results()
+
+    async def process_audio(self, data):
+        self.processed.append(data)
+        if not data:
+            self.stop.set()
+
+    async def cleanup(self):
+        self.cleanup_called = True
+
+
+@pytest.mark.asyncio
+async def test_close_stream_drains_results_before_summary_and_close(monkeypatch):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    DelayedFinalProcessor.instances = []
+    monkeypatch.setattr(audio_processor_module, "AudioProcessor", DelayedFinalProcessor)
+    websocket = RecordingWebSocket(
+        {"endpointing": "false"},
+        [{"type": "websocket.receive", "text": '{"type":"CloseStream"}'}],
+    )
+
+    await handle_deepgram_websocket(
+        websocket,
+        transcription_engine=object(),
+        config=SimpleNamespace(vac=True, backend="fake"),
+    )
+
+    processor = DelayedFinalProcessor.instances[0]
+    assert processor.create_tasks_calls == 1
+    assert processor.processed == [b""]
+    assert processor.cleanup_called
+    assert websocket.closed[0] == 1000
+    assert [message["type"] for message in websocket.sent] == [
+        "Metadata",
+        "Results",
+        "Metadata",
+    ]
+    assert _transcript(websocket.sent[1]) == "tail"
+    assert websocket.sent[-1]["duration"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_frontdata_error_is_forwarded_and_closes_immediately(monkeypatch):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    class ErrorProcessor(DelayedFinalProcessor):
+        async def create_tasks(self):
+            self.create_tasks_calls += 1
+
+            async def results():
+                yield FrontData(status="error", error="decoder failed")
+
+            return results()
+
+    ErrorProcessor.instances = []
+    monkeypatch.setattr(audio_processor_module, "AudioProcessor", ErrorProcessor)
+    websocket = RecordingWebSocket({"endpointing": "false"})
+
+    await handle_deepgram_websocket(
+        websocket,
+        transcription_engine=object(),
+        config=SimpleNamespace(vac=True, backend="fake"),
+    )
+
+    processor = ErrorProcessor.instances[0]
+    assert processor.cleanup_called
+    assert websocket.closed[0] == 1011
+    assert websocket.sent[-1]["type"] == "Error"
+    assert websocket.sent[-1]["description"] == "decoder failed"
+
+
+@pytest.mark.asyncio
+async def test_create_tasks_failure_closes_and_cleans_up(monkeypatch):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    class SetupFailureProcessor(DelayedFinalProcessor):
+        async def create_tasks(self):
+            self.create_tasks_calls += 1
+            raise RuntimeError("setup exploded")
+
+    SetupFailureProcessor.instances = []
+    monkeypatch.setattr(
+        audio_processor_module,
+        "AudioProcessor",
+        SetupFailureProcessor,
+    )
+    websocket = RecordingWebSocket({"endpointing": "false"})
+
+    await handle_deepgram_websocket(
+        websocket,
+        transcription_engine=object(),
+        config=SimpleNamespace(vac=True, backend="fake"),
+    )
+
+    processor = SetupFailureProcessor.instances[0]
+    assert processor.create_tasks_calls == 1
+    assert processor.cleanup_called
+    assert websocket.closed[0] == 1011
+    assert [message["type"] for message in websocket.sent] == [
+        "Metadata",
+        "Error",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handshake_disconnect_still_cleans_up_processor(monkeypatch):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    class DisconnectOnAccept(RecordingWebSocket):
+        async def accept(self):
+            raise RuntimeError("client left during handshake")
+
+    DelayedFinalProcessor.instances = []
+    monkeypatch.setattr(
+        audio_processor_module,
+        "AudioProcessor",
+        DelayedFinalProcessor,
+    )
+    websocket = DisconnectOnAccept({"endpointing": "false"})
+
+    await handle_deepgram_websocket(
+        websocket,
+        transcription_engine=object(),
+        config=SimpleNamespace(vac=True, backend="fake"),
+    )
+
+    assert DelayedFinalProcessor.instances[0].cleanup_called
+    assert websocket.closed[0] == 1011
+
+
+@pytest.mark.asyncio
+async def test_result_generator_failure_closes_without_waiting_for_timeout(monkeypatch):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    class GeneratorFailureProcessor(DelayedFinalProcessor):
+        async def create_tasks(self):
+            self.create_tasks_calls += 1
+
+            async def results():
+                if False:
+                    yield None
+                raise RuntimeError("generator exploded")
+
+            return results()
+
+    GeneratorFailureProcessor.instances = []
+    monkeypatch.setattr(
+        audio_processor_module,
+        "AudioProcessor",
+        GeneratorFailureProcessor,
+    )
+    websocket = RecordingWebSocket({"endpointing": "false"})
+
+    await asyncio.wait_for(
+        handle_deepgram_websocket(
+            websocket,
+            transcription_engine=object(),
+            config=SimpleNamespace(vac=True, backend="fake"),
+        ),
+        timeout=1,
+    )
+
+    processor = GeneratorFailureProcessor.instances[0]
+    assert processor.cleanup_called
+    assert websocket.closed[0] == 1011
+    assert websocket.sent[-1]["description"] == "Transcription result stream failed."
+
+
+@pytest.mark.asyncio
+async def test_event_consumer_failure_closes_without_waiting_for_timeout(monkeypatch):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    class MalformedResultProcessor(DelayedFinalProcessor):
+        async def create_tasks(self):
+            self.create_tasks_calls += 1
+
+            async def results():
+                yield FrontData(lines=[object()])
+
+            return results()
+
+    MalformedResultProcessor.instances = []
+    monkeypatch.setattr(
+        audio_processor_module,
+        "AudioProcessor",
+        MalformedResultProcessor,
+    )
+    websocket = RecordingWebSocket({"endpointing": "false"})
+
+    await asyncio.wait_for(
+        handle_deepgram_websocket(
+            websocket,
+            transcription_engine=object(),
+            config=SimpleNamespace(vac=True, backend="fake"),
+        ),
+        timeout=1,
+    )
+
+    assert MalformedResultProcessor.instances[0].cleanup_called
+    assert websocket.closed[0] == 1011
+    assert websocket.sent[-1]["description"] == "Transcription event stream failed."
+
+
+@pytest.mark.asyncio
+async def test_ordered_results_are_sent_before_later_stream_error(monkeypatch):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    class SlowRecordingWebSocket(RecordingWebSocket):
+        async def send_json(self, message):
+            if message.get("type") == "Results":
+                await asyncio.sleep(0.01)
+            await super().send_json(message)
+
+    class ResultsThenErrorProcessor(DelayedFinalProcessor):
+        async def create_tasks(self):
+            self.create_tasks_calls += 1
+
+            async def results():
+                one = _token(0.0, 0.2, "one")
+                two = _token(0.2, 0.4, "two")
+                three = _token(0.4, 0.6, "three")
+                yield FrontData(lines=[_speech_line(one)])
+                yield FrontData(lines=[_speech_line(one, two)])
+                yield FrontData(lines=[_speech_line(one, two, three)])
+                yield FrontData(status="error", error="late failure")
+
+            return results()
+
+    ResultsThenErrorProcessor.instances = []
+    monkeypatch.setattr(
+        audio_processor_module,
+        "AudioProcessor",
+        ResultsThenErrorProcessor,
+    )
+    websocket = SlowRecordingWebSocket(
+        {"endpointing": "false", "interim_results": "true"}
+    )
+
+    await asyncio.wait_for(
+        handle_deepgram_websocket(
+            websocket,
+            transcription_engine=object(),
+            config=SimpleNamespace(vac=True, backend="fake"),
+        ),
+        timeout=1,
+    )
+
+    assert [_transcript(message) for message in _results(websocket, final=True)] == [
+        "one",
+        "two",
+    ]
+    assert websocket.sent[-1]["type"] == "Error"
+    assert websocket.sent[-1]["description"] == "late failure"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("incoming", "error_fragment"),
+    [
+        (
+            {"type": "websocket.receive", "bytes": b""},
+            "Empty binary frames",
+        ),
+        (
+            {"type": "websocket.receive", "text": '{"type":"Finalize"}'},
+            "Finalize is not supported",
+        ),
+    ],
+)
+async def test_unsupported_terminal_inputs_fail_explicitly(
+    monkeypatch,
+    incoming,
+    error_fragment,
+):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    DelayedFinalProcessor.instances = []
+    monkeypatch.setattr(audio_processor_module, "AudioProcessor", DelayedFinalProcessor)
+    websocket = RecordingWebSocket(
+        {"endpointing": "false"},
+        [incoming],
+    )
+
+    await handle_deepgram_websocket(
+        websocket,
+        transcription_engine=object(),
+        config=SimpleNamespace(vac=True, backend="fake"),
+    )
+
+    processor = DelayedFinalProcessor.instances[0]
+    assert processor.processed == []
+    assert processor.create_tasks_calls == 1
+    assert processor.cleanup_called
+    assert websocket.closed[0] == 4400
+    assert error_fragment in websocket.sent[-1]["description"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_query_is_rejected_before_processor_construction(monkeypatch):
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    def fail_if_constructed(**kwargs):
+        raise AssertionError(f"processor should not be constructed: {kwargs}")
+
+    monkeypatch.setattr(audio_processor_module, "AudioProcessor", fail_if_constructed)
+    websocket = RecordingWebSocket({"utterance_end_ms": "1000"})
+
+    await handle_deepgram_websocket(
+        websocket,
+        transcription_engine=object(),
+        config=SimpleNamespace(vac=True),
+    )
+
+    assert websocket.accepted
+    assert websocket.closed[0] == 4400
+    assert "requires interim_results=true" in websocket.sent[0]["description"]
+
+
+@pytest.mark.asyncio
+async def test_audio_processor_emits_sample_clock_silence_events():
+    from whisperlivekit.audio_processor import AudioProcessor
+    from whisperlivekit.metrics_collector import SessionMetrics
+    from whisperlivekit.timed_objects import Silence, State
+
+    processor = object.__new__(AudioProcessor)
+    processor.stream_event_queue = asyncio.Queue()
+    processor.sample_rate = 100
+    processor.total_pcm_samples = 100
+    processor.current_silence = None
+    processor.transcription_queue = None
+    processor.diarization_queue = None
+    processor.translation_queue = None
+    processor.args = SimpleNamespace(diarization=False)
+    processor.metrics = SessionMetrics()
+    processor.state = State()
+    processor.pause_segmentation_seconds = 5.0
+
+    await processor._begin_silence(at_sample=125)
+    assert isinstance(processor.current_silence, Silence)
+    await processor._end_silence(at_sample=150, speech_resumed=True)
+
+    events = []
+    while not processor.stream_event_queue.empty():
+        events.append(processor.stream_event_queue.get_nowait())
+    assert events == [
+        AudioStreamEvent("silence_started", 1.25),
+        AudioStreamEvent("silence_transcription_ready", 1.25),
+        AudioStreamEvent("speech_started", 1.5),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcription_ready_event_waits_for_matching_snapshot():
+    from whisperlivekit.audio_processor import AudioProcessor
+    from whisperlivekit.metrics_collector import SessionMetrics
+    from whisperlivekit.timed_objects import State
+
+    processor = object.__new__(AudioProcessor)
+    processor.stream_event_queue = asyncio.Queue()
+    processor._stream_events_after_snapshot = asyncio.Queue()
+    processor._ffmpeg_error = None
+    processor.tokens_alignment = SimpleNamespace(
+        update=lambda: None,
+        get_lines=lambda **kwargs: ([], "", ""),
+    )
+    processor.args = SimpleNamespace(diarization=False)
+    processor.translation = None
+    processor.total_pcm_samples = 0
+    processor.sample_rate = 16000
+    processor.last_response_content = FrontData(status="no_audio_detected")
+    processor.metrics = SessionMetrics()
+    processor.is_stopping = False
+
+    async def get_current_state():
+        return State()
+
+    processor.get_current_state = get_current_state
+    barrier = asyncio.create_task(
+        processor._emit_stream_event_after_snapshot(
+            "silence_transcription_ready",
+            1.25,
+        )
+    )
+    await asyncio.sleep(0)
+    assert not barrier.done()
+    assert processor.stream_event_queue.empty()
+
+    generator = processor.results_formatter()
+    response = await anext(generator)
+    assert response.status == "no_audio_detected"
+    assert processor.stream_event_queue.empty()
+
+    resume = asyncio.create_task(anext(generator))
+    for _ in range(20):
+        if not processor.stream_event_queue.empty():
+            break
+        await asyncio.sleep(0)
+    assert processor.stream_event_queue.get_nowait() == AudioStreamEvent(
+        "silence_transcription_ready",
+        1.25,
+    )
+    await asyncio.wait_for(barrier, timeout=1)
+    resume.cancel()
+    await asyncio.gather(resume, return_exceptions=True)
+    await generator.aclose()
+
+
+@pytest.mark.asyncio
+async def test_current_deepgram_sdk_receives_typed_exactly_once_close_stream(
+    monkeypatch,
+):
+    import socket
+
+    import uvicorn
+    from deepgram import AsyncDeepgramClient
+    from deepgram.environment import DeepgramClientEnvironment
+    from deepgram.listen.v1.types.listen_v1metadata import ListenV1Metadata
+    from deepgram.listen.v1.types.listen_v1results import ListenV1Results
+    from fastapi import FastAPI, WebSocket
+
+    from whisperlivekit import audio_processor as audio_processor_module
+
+    class SdkProcessor(DelayedFinalProcessor):
+        async def create_tasks(self):
+            self.create_tasks_calls += 1
+
+            async def results():
+                await self.stop.wait()
+                hello = _token(0.0, 0.25, "hello")
+                world = _token(0.25, 0.5, "world")
+                yield FrontData(lines=[_speech_line(hello)])
+                yield FrontData(lines=[_speech_line(hello, world)])
+
+            return results()
+
+    monkeypatch.setattr(audio_processor_module, "AudioProcessor", SdkProcessor)
+    app = FastAPI()
+    config = SimpleNamespace(vac=True, backend="fake")
+
+    @app.websocket("/v1/listen")
+    async def listen(websocket: WebSocket):
+        await handle_deepgram_websocket(websocket, object(), config)
+
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = listener.getsockname()[1]
+    server = uvicorn.Server(
+        uvicorn.Config(app, log_level="error", lifespan="off")
+    )
+    server_task = asyncio.create_task(server.serve(sockets=[listener]))
+    for _ in range(200):
+        if server.started:
+            break
+        await asyncio.sleep(0.01)
+    assert server.started
+
+    origin = f"127.0.0.1:{port}"
+    environment = DeepgramClientEnvironment(
+        base=f"http://{origin}",
+        production=f"ws://{origin}",
+        agent=f"ws://{origin}",
+        agent_rest=f"http://{origin}",
+    )
+    client = AsyncDeepgramClient(api_key="unused", environment=environment)
+    received = []
+    try:
+        async with client.listen.v1.connect(
+            model="nova-3",
+            encoding="linear16",
+            sample_rate=16000,
+            channels=1,
+            interim_results=True,
+            endpointing=False,
+        ) as connection:
+            await connection.send_media(b"\x00\x00")
+            initial = await asyncio.wait_for(connection.recv(), timeout=2)
+            assert isinstance(initial, ListenV1Metadata)
+            assert initial.transaction_key == "deprecated"
+
+            await connection.send_close_stream()
+            while True:
+                message = await asyncio.wait_for(connection.recv(), timeout=2)
+                received.append(message)
+                if isinstance(message, ListenV1Metadata):
+                    break
+    finally:
+        server.should_exit = True
+        await asyncio.wait_for(server_task, timeout=5)
+        listener.close()
+
+    finals = [
+        message
+        for message in received
+        if isinstance(message, ListenV1Results) and message.is_final
+    ]
+    assert [message.channel.alternatives[0].transcript for message in finals] == [
+        "hello",
+        "world",
+    ]
+    assert all(message.metadata.request_id for message in finals)
+    assert all(message.metadata.model_uuid for message in finals)
+    assert received[-1].duration == 0.5
+    processor = SdkProcessor.instances[-1]
+    assert processor.kwargs["pcm_input"] is True
+    assert processor.processed == [b"\x00\x00", b""]

--- a/uv.lock
+++ b/uv.lock
@@ -1955,6 +1955,22 @@ wheels = [
 ]
 
 [[package]]
+name = "deepgram-sdk"
+version = "7.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/62/35862ebd6dc3873d7f67319afb775143b86fbf0fa1b1ab6697249325bfd4/deepgram_sdk-7.7.0.tar.gz", hash = "sha256:4cce45c853d6caebbed62081d9118b915a2f3a2e54eb420ff5148c30e16dcffd", size = 242704, upload-time = "2026-08-12T13:26:28.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/fa/7db3da57efe9b7919d57c4aac0eb9cbdf2ee40ed766316aada60cce89c03/deepgram_sdk-7.7.0-py3-none-any.whl", hash = "sha256:25355b2e119f969c8614136e494ef30be91a06c56152a9cba49535ef3f18f82c", size = 633789, upload-time = "2026-08-12T13:26:26.738Z" },
+]
+
+[[package]]
 name = "depyf"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -11167,6 +11183,7 @@ sentence-tokenizer = [
 ]
 test = [
     { name = "datasets" },
+    { name = "deepgram-sdk" },
     { name = "librosa" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -11195,6 +11212,7 @@ dev = [
 requires-dist = [
     { name = "accelerate", marker = "extra == 'voxtral-hf'", specifier = ">=0.12" },
     { name = "datasets", marker = "extra == 'test'", specifier = ">=2.14" },
+    { name = "deepgram-sdk", marker = "extra == 'test'", specifier = "==7.7.0" },
     { name = "diart", marker = "python_full_version < '3.13' and extra == 'diarization-diart'", specifier = "==0.9.2" },
     { name = "fastapi", specifier = ">=0.141.1" },
     { name = "faster-whisper", specifier = ">=1.2.0" },

--- a/whisperlivekit/api_auth.py
+++ b/whisperlivekit/api_auth.py
@@ -1,0 +1,17 @@
+"""Shared authentication helpers for HTTP and WebSocket APIs."""
+
+from typing import Optional
+
+from fastapi import WebSocket
+
+
+def websocket_token(websocket: WebSocket) -> Optional[str]:
+    """Read WLK query auth plus Bearer or Deepgram-style Token headers."""
+    candidate = websocket.query_params.get("token")
+    if candidate:
+        return candidate
+    auth = websocket.headers.get("authorization") or ""
+    scheme, _, value = auth.partition(" ")
+    if scheme.lower() in {"bearer", "token"}:
+        return value.strip() or None
+    return None

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -18,7 +18,16 @@ from whisperlivekit.core import (
 from whisperlivekit.ffmpeg_manager import FFmpegManager, FFmpegState
 from whisperlivekit.metrics_collector import SessionMetrics
 from whisperlivekit.silero_vad_iterator import FixedVADIterator, OnnxWrapper, load_jit_vad
-from whisperlivekit.timed_objects import ASRToken, ChangeSpeaker, FrontData, HypothesisTail, Silence, State, Transcript
+from whisperlivekit.timed_objects import (
+    ASRToken,
+    AudioStreamEvent,
+    ChangeSpeaker,
+    FrontData,
+    HypothesisTail,
+    Silence,
+    State,
+    Transcript,
+)
 from whisperlivekit.tokens_alignment import TokensAlignment, resolve_retention_seconds
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -92,6 +101,11 @@ class AudioProcessor:
         """Initialize the audio processor with configuration, models, and state."""
         # Extract per-session options before passing to TranscriptionEngine
         session_language = kwargs.pop('language', None)
+        self.stream_event_queue = kwargs.pop('stream_event_queue', None)
+        self._stream_events_after_snapshot = (
+            asyncio.Queue() if self.stream_event_queue is not None else None
+        )
+        session_pcm_input = kwargs.pop('pcm_input', None)
         # Output mode of the session: "full" resends the whole transcript on
         # every update, so history must never be pruned away (issue #372);
         # "diff" clients keep their own copy and allow bounded server memory.
@@ -120,7 +134,11 @@ class AudioProcessor:
         self.bytes_per_sample = 2
         self.bytes_per_sec = self.samples_per_sec * self.bytes_per_sample
         self.max_bytes_per_sec = 32000 * 5  # 5 seconds of audio at 32 kHz
-        self.is_pcm_input = self.args.pcm_input
+        self.is_pcm_input = (
+            self.args.pcm_input
+            if session_pcm_input is None
+            else bool(session_pcm_input)
+        )
 
         # State management
         self.is_stopping: bool = False
@@ -210,6 +228,32 @@ class AudioProcessor:
         # Silent-backend watchdog: flips once the ASR has produced anything.
         self._any_asr_output: bool = False
         self._silent_backend_warned: bool = False
+
+    async def _emit_stream_event(self, kind: str, timestamp: float) -> None:
+        """Publish a protocol-neutral event on the submitted audio clock."""
+        event_queue = getattr(self, "stream_event_queue", None)
+        if event_queue is not None:
+            await event_queue.put(
+                AudioStreamEvent(kind=kind, timestamp=float(timestamp))
+            )
+
+    async def _emit_stream_event_after_snapshot(
+        self,
+        kind: str,
+        timestamp: float,
+    ) -> None:
+        """Publish only after results_formatter yields the matching state."""
+        pending_queue = getattr(self, "_stream_events_after_snapshot", None)
+        if pending_queue is None:
+            return
+        acknowledged = asyncio.get_running_loop().create_future()
+        await pending_queue.put(
+            (
+                AudioStreamEvent(kind=kind, timestamp=float(timestamp)),
+                acknowledged,
+            )
+        )
+        await acknowledged
 
     async def _queue_tokens_for_translation(self, tokens: List[ASRToken]) -> None:
         """Forward committed tokens to the translation queue.
@@ -304,6 +348,7 @@ class AudioProcessor:
         self.current_silence = Silence(
             is_starting=True, start=audio_t
         )
+        await self._emit_stream_event("silence_started", audio_t)
         # Push a separate start-only event so _end_silence won't mutate it
         start_event = Silence(is_starting=True, start=audio_t)
         if self.transcription_queue:
@@ -313,6 +358,8 @@ class AudioProcessor:
         if self.translation_queue and not self.transcription_queue:
             await self._flush_pending_translation_tokens()
             await self.translation_queue.put(start_event)
+        if not self.transcription_queue:
+            await self._emit_stream_event("silence_transcription_ready", audio_t)
 
     def _is_pause_segmentation_boundary(self, silence: Silence) -> bool:
         """Whether a completed pause crosses the output threshold."""
@@ -326,7 +373,12 @@ class AudioProcessor:
         duration = silence.duration
         return duration is not None and duration > threshold
 
-    async def _end_silence(self, at_sample: Optional[int] = None) -> None:
+    async def _end_silence(
+        self,
+        at_sample: Optional[int] = None,
+        *,
+        speech_resumed: bool = False,
+    ) -> None:
         if not self.current_silence:
             return
         if at_sample is not None:
@@ -350,6 +402,8 @@ class AudioProcessor:
         # Push the completed silence as the end event (separate from the start event)
         await self._push_silence_event()
         self.current_silence = None
+        if speech_resumed:
+            await self._emit_stream_event("speech_started", audio_t)
 
     async def _enqueue_active_audio(self, pcm_chunk: np.ndarray) -> None:
         if pcm_chunk is None or pcm_chunk.size == 0:
@@ -745,6 +799,11 @@ class AudioProcessor:
 
                 await self._queue_tokens_for_translation(new_tokens)
                 await self._queue_hypothesis_tail_for_translation(_buffer_transcript)
+                if isinstance(item, Silence) and item.is_starting:
+                    await self._emit_stream_event_after_snapshot(
+                        "silence_transcription_ready",
+                        item.start or 0.0,
+                    )
                 if isinstance(item, Silence) and self.translation_queue:
                     # The silence-start ASR call can commit the final words of
                     # the utterance. Forward those words before resetting the
@@ -901,11 +960,25 @@ class AudioProcessor:
                     remaining_time_diarization=state.remaining_time_diarization if self.args.diarization else 0
                 )
 
-                should_push = (response != self.last_response_content)
+                deferred_events = []
+                pending_queue = getattr(self, "_stream_events_after_snapshot", None)
+                if pending_queue is not None:
+                    while not pending_queue.empty():
+                        deferred_events.append(pending_queue.get_nowait())
+
+                should_push = (
+                    response != self.last_response_content
+                    or bool(deferred_events)
+                )
                 if should_push:
                     self.metrics.n_responses_sent += 1
                     yield response
                     self.last_response_content = response
+                for event, acknowledged in deferred_events:
+                    await self.stream_event_queue.put(event)
+                    if not acknowledged.done():
+                        acknowledged.set_result(None)
+                    pending_queue.task_done()
 
                 if self.is_stopping and self._processing_tasks_done():
                     logger.info("Results formatter: All upstream processors are done and in stopping state. Terminating.")
@@ -1070,7 +1143,7 @@ class AudioProcessor:
         # Without VAC, there's no speech detector to end the initial silence.
         # Clear it on the first audio chunk so audio actually gets enqueued.
         if not self.args.vac and self.current_silence:
-            await self._end_silence()
+            await self._end_silence(speech_resumed=True)
 
         # Process when enough data
         if len(self.pcm_buffer) < self.bytes_per_sec:
@@ -1103,7 +1176,10 @@ class AudioProcessor:
         # EOF can send a sub-chunk directly here. Without VAC, clear the
         # initial placeholder before treating that tail as active speech.
         if not self.args.vac and self.current_silence:
-            await self._end_silence(at_sample=self.total_pcm_samples)
+            await self._end_silence(
+                at_sample=self.total_pcm_samples,
+                speech_resumed=True,
+            )
 
         num_samples = len(pcm_array)
         chunk_sample_start = self.total_pcm_samples
@@ -1128,7 +1204,10 @@ class AudioProcessor:
                 # ensuring all active audio in the current chunk is captured.
                 start_sample_eff = max(chunk_sample_start, min(chunk_sample_end, start_sample))
                 start_offset = start_sample_eff - chunk_sample_start
-                await self._end_silence(at_sample=start_sample_eff)
+                await self._end_silence(
+                    at_sample=start_sample_eff,
+                    speech_resumed=True,
+                )
                 last_offset = start_offset
 
             if "end" in event and not self.current_silence:
@@ -1148,6 +1227,10 @@ class AudioProcessor:
             await self._enqueue_active_audio(pcm_array[last_offset:])
 
         self.total_pcm_samples = chunk_sample_end
+        await self._emit_stream_event(
+            "audio_advanced",
+            self.total_pcm_samples / self.sample_rate,
+        )
 
     async def _finalize_current_silence_at_stream_end(self) -> None:
         """Commit a trailing pause at the final known stream position."""

--- a/whisperlivekit/basic_server.py
+++ b/whisperlivekit/basic_server.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
 from whisperlivekit import AudioProcessor, TranscriptionEngine, get_inline_ui_html, parse_args
+from whisperlivekit.api_auth import websocket_token
 from whisperlivekit.config import parse_cors_origins
 from whisperlivekit.timed_objects import FrontData
 
@@ -36,6 +37,7 @@ def _bearer_token(request: Request) -> Optional[str]:
     if auth.lower().startswith("bearer "):
         return auth[7:].strip()
     return None
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -92,10 +94,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
     # Authentication (when --api-token / WLK_API_TOKEN is set): accept the
     # token either as a query parameter or an Authorization: Bearer header.
-    ws_auth = websocket.headers.get("authorization") or ""
-    ws_token = websocket.query_params.get("token") or (
-        ws_auth[7:].strip() if ws_auth.lower().startswith("bearer ") else None
-    )
+    ws_token = websocket_token(websocket)
     if not _token_ok(ws_token):
         await websocket.close(code=4401, reason="invalid or missing API token")
         logger.warning("WebSocket rejected: invalid or missing API token")
@@ -179,6 +178,10 @@ async def websocket_endpoint(websocket: WebSocket):
 async def deepgram_websocket_endpoint(websocket: WebSocket):
     """Deepgram-compatible live transcription WebSocket."""
     global transcription_engine
+    if not _token_ok(websocket_token(websocket)):
+        await websocket.close(code=4401, reason="invalid or missing API token")
+        logger.warning("Deepgram WebSocket rejected: invalid or missing API token")
+        return
     from whisperlivekit.deepgram_compat import handle_deepgram_websocket
     await handle_deepgram_websocket(websocket, transcription_engine, config)
 

--- a/whisperlivekit/deepgram_compat.py
+++ b/whisperlivekit/deepgram_compat.py
@@ -1,33 +1,43 @@
-"""Deepgram-compatible WebSocket endpoint for WhisperLiveKit.
+"""Deepgram Live Transcription compatibility for WhisperLiveKit.
 
-Provides a /v1/listen endpoint that speaks the Deepgram Live Transcription
-protocol, enabling drop-in compatibility with Deepgram client SDKs.
+The adapter keeps Deepgram's independent concepts separate:
 
-Protocol mapping:
-  - Client sends binary audio frames → forwarded to AudioProcessor
-  - Client sends JSON control messages (KeepAlive, CloseStream, Finalize)
-  - Server sends Results, Metadata, UtteranceEnd messages
-
-Differences from Deepgram:
-  - No authentication required (self-hosted)
-  - Word-level timestamps approximate (interpolated from segment boundaries)
-  - Confidence scores not available (set to 0.0)
+* interim hypotheses may be replaced;
+* final word ranges are immutable and emitted exactly once;
+* endpointing is driven by VAD pauses on the submitted audio clock;
+* UtteranceEnd is a separate gap detector anchored to a finalized word.
 """
 
 import asyncio
 import json
 import logging
+import re
 import time
+import unicodedata
 import uuid
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
 
 from fastapi import WebSocket, WebSocketDisconnect
 
+from whisperlivekit.timed_objects import AudioStreamEvent, FrontData
+
 logger = logging.getLogger(__name__)
 
+_DEFAULT_ENDPOINTING_MS = 10
+_MIN_UTTERANCE_END_MS = 1000
+_MAX_UTTERANCE_END_MS = 5000
+_EVENTS_DONE = object()
 
-def _parse_time_str(time_str: str) -> float:
-    """Parse 'H:MM:SS.cc' to seconds."""
-    parts = time_str.split(":")
+
+def _parse_time_str(value: Any) -> float:
+    """Parse a frontend timestamp or pass through a numeric timestamp."""
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    parts = str(value).split(":")
     if len(parts) == 3:
         return int(parts[0]) * 3600 + int(parts[1]) * 60 + float(parts[2])
     if len(parts) == 2:
@@ -35,286 +45,1087 @@ def _parse_time_str(time_str: str) -> float:
     return float(parts[0])
 
 
-def _line_to_words(line: dict) -> list:
-    """Convert a line dict to Deepgram-style word objects.
+def _parse_bool(params: Mapping[str, str], name: str, default: bool) -> bool:
+    raw = params.get(name)
+    if raw is None:
+        return default
+    normalized = str(raw).strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise ValueError(f"{name} must be true or false.")
 
-    Distributes timestamps proportionally across words since
-    WhisperLiveKit provides segment-level timestamps.
-    """
-    text = line.get("text", "")
-    if not text or not text.strip():
+
+def _parse_integer_ms(raw: Any, name: str) -> int:
+    value = str(raw).strip()
+    if not value or not value.isascii() or not value.isdecimal():
+        raise ValueError(f"{name} must be an integer number of milliseconds.")
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError(f"{name} must be greater than zero.")
+    return parsed
+
+
+def _parse_positive_integer(raw: Any, name: str) -> int:
+    value = str(raw).strip()
+    if not value or not value.isascii() or not value.isdecimal():
+        raise ValueError(f"{name} must be a positive integer.")
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return parsed
+
+
+@dataclass(frozen=True)
+class DeepgramOptions:
+    """Supported per-connection Deepgram query options."""
+
+    language: Optional[str]
+    interim_results: bool
+    vad_events: bool
+    endpointing_ms: Optional[int]
+    utterance_end_ms: Optional[int]
+    pcm_input: Optional[bool] = None
+
+    @classmethod
+    def from_query_params(
+        cls,
+        params: Mapping[str, str],
+        *,
+        vac_enabled: bool,
+    ) -> "DeepgramOptions":
+        interim_results = _parse_bool(params, "interim_results", False)
+        vad_events = _parse_bool(params, "vad_events", False)
+
+        endpointing_raw = params.get("endpointing")
+        if endpointing_raw is None:
+            endpointing_ms: Optional[int] = _DEFAULT_ENDPOINTING_MS
+        elif str(endpointing_raw).strip().lower() == "false":
+            endpointing_ms = None
+        elif str(endpointing_raw).strip().lower() == "true":
+            endpointing_ms = _DEFAULT_ENDPOINTING_MS
+        else:
+            endpointing_ms = _parse_integer_ms(endpointing_raw, "endpointing")
+
+        if endpointing_ms is not None and not vac_enabled:
+            raise ValueError(
+                "endpointing requires VAC. Enable --vac or use endpointing=false."
+            )
+        if vad_events and not vac_enabled:
+            raise ValueError("vad_events requires VAC. Enable --vac or use vad_events=false.")
+
+        utterance_raw = params.get("utterance_end_ms")
+        utterance_end_ms = None
+        if utterance_raw is not None:
+            utterance_end_ms = _parse_integer_ms(
+                utterance_raw,
+                "utterance_end_ms",
+            )
+            if not _MIN_UTTERANCE_END_MS <= utterance_end_ms <= _MAX_UTTERANCE_END_MS:
+                raise ValueError(
+                    "utterance_end_ms must be an integer between 1000 and 5000."
+                )
+            if not interim_results:
+                raise ValueError(
+                    "utterance_end_ms requires interim_results=true."
+                )
+
+        encoding_raw = params.get("encoding")
+        encoding = str(encoding_raw).strip().lower() if encoding_raw else None
+        if encoding not in {None, "linear16"}:
+            raise ValueError("encoding must be linear16 when specified.")
+
+        sample_rate_raw = params.get("sample_rate")
+        if encoding == "linear16" and sample_rate_raw is None:
+            raise ValueError("sample_rate=16000 is required with encoding=linear16.")
+        if sample_rate_raw is not None:
+            sample_rate = _parse_positive_integer(sample_rate_raw, "sample_rate")
+            if sample_rate != 16000:
+                raise ValueError("WhisperLiveKit supports sample_rate=16000 only.")
+
+        channels_raw = params.get("channels")
+        if channels_raw is not None:
+            channels = _parse_positive_integer(channels_raw, "channels")
+            if channels != 1:
+                raise ValueError("WhisperLiveKit supports channels=1 only.")
+
+        return cls(
+            language=params.get("language"),
+            interim_results=interim_results,
+            vad_events=vad_events,
+            endpointing_ms=endpointing_ms,
+            utterance_end_ms=utterance_end_ms,
+            pcm_input=True if encoding == "linear16" else None,
+        )
+
+
+@dataclass(frozen=True)
+class _SilenceBoundary:
+    word_count: int
+    start: float
+    end: float
+
+
+@dataclass
+class _PauseState:
+    start: float
+    end: Optional[float] = None
+    transcription_ready: bool = False
+    endpointed: bool = False
+    resume_timestamp: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class _StreamFailure:
+    description: str
+
+
+def _speaker_index(value: Any) -> int:
+    try:
+        speaker = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, speaker - 1)
+
+
+def _span_to_words(
+    text: str,
+    start: float,
+    end: float,
+    speaker: int,
+) -> list[dict[str, Any]]:
+    """Split one timestamped source span into Deepgram word objects."""
+    source_text = str(text or "")
+    matches = list(re.finditer(r"\S+", source_text))
+    if not matches:
         return []
-
-    start = _parse_time_str(line.get("start", "0:00:00"))
-    end = _parse_time_str(line.get("end", "0:00:00"))
-    speaker = line.get("speaker", 0)
-    if speaker == -2:
-        return []
-
-    words = text.split()
-    if not words:
-        return []
-
-    duration = end - start
-    step = duration / max(len(words), 1)
-
-    return [
-        {
-            "word": w,
-            "start": round(start + i * step, 3),
-            "end": round(start + (i + 1) * step, 3),
-            "confidence": 0.0,
-            "punctuated_word": w,
-            "speaker": speaker if speaker > 0 else 0,
-        }
-        for i, w in enumerate(words)
-    ]
+    duration = max(0.0, end - start)
+    step = duration / len(matches)
+    words = []
+    previous_end = 0
+    for index, match in enumerate(matches):
+        piece = match.group(0)
+        word_start = start + index * step
+        word_end = end if index == len(matches) - 1 else start + (index + 1) * step
+        words.append(
+            {
+                "word": piece,
+                "start": round(word_start, 3),
+                "end": round(word_end, 3),
+                "confidence": 0.0,
+                "punctuated_word": piece,
+                "speaker": speaker,
+                "_source_text": source_text[previous_end:match.end()],
+            }
+        )
+        previous_end = match.end()
+    words[-1]["_source_text"] += source_text[previous_end:]
+    return words
 
 
-def _lines_to_result(lines: list, is_final: bool, speech_final: bool,
-                     start_time: float = 0.0) -> dict:
-    """Convert FrontData lines to a Deepgram Results message."""
-    all_words = []
-    full_text_parts = []
-
-    for line in lines:
+def _line_to_words(line: Any) -> list[dict[str, Any]]:
+    """Convert one Segment or serialized line without losing real token times."""
+    if isinstance(line, dict):
         if line.get("speaker") == -2:
-            continue
-        words = _line_to_words(line)
-        all_words.extend(words)
-        text = line.get("text", "")
-        if text and text.strip():
-            full_text_parts.append(text.strip())
+            return []
+        return _span_to_words(
+            line.get("text", ""),
+            _parse_time_str(line.get("start", 0.0)),
+            _parse_time_str(line.get("end", 0.0)),
+            _speaker_index(line.get("speaker", 1)),
+        )
 
-    transcript = " ".join(full_text_parts)
+    if line.is_silence():
+        return []
+    speaker = _speaker_index(getattr(line, "speaker", 1))
+    tokens = getattr(line, "tokens", None) or []
+    if tokens:
+        words = []
+        for token in tokens:
+            words.extend(
+                _span_to_words(
+                    token.text,
+                    float(token.start or 0.0),
+                    float(token.end or token.start or 0.0),
+                    speaker,
+                )
+            )
+        return words
+    return _span_to_words(
+        getattr(line, "text", ""),
+        float(getattr(line, "start", 0.0) or 0.0),
+        float(getattr(line, "end", 0.0) or 0.0),
+        speaker,
+    )
 
-    # Calculate duration from word boundaries
-    if all_words:
-        seg_start = all_words[0]["start"]
-        seg_end = all_words[-1]["end"]
-        duration = seg_end - seg_start
+
+def _punctuation_only(text: str) -> bool:
+    return bool(text) and all(
+        unicodedata.category(character).startswith("P")
+        for character in text
+    )
+
+
+def _append_word(
+    words: list[dict[str, Any]],
+    word: dict[str, Any],
+    group_start: int,
+) -> None:
+    """Attach punctuation-only tokens to the preceding Deepgram word."""
+    text = str(word.get("punctuated_word") or word.get("word") or "").strip()
+    if _punctuation_only(text) and len(words) > group_start:
+        previous = words[-1]
+        previous["punctuated_word"] = (
+            str(previous.get("punctuated_word") or previous.get("word") or "")
+            + text
+        )
+        previous["end"] = max(float(previous["end"]), float(word["end"]))
+        previous["_source_text"] = (
+            str(previous.get("_source_text") or "")
+            + str(word.get("_source_text") or text)
+        )
+        return
+    if (
+        not _punctuation_only(text)
+        and len(words) > group_start
+        and _punctuation_only(
+            str(words[-1].get("word") or "").strip()
+        )
+    ):
+        leading = words.pop()
+        word["punctuated_word"] = (
+            str(leading.get("punctuated_word") or leading.get("word") or "")
+            + str(word.get("punctuated_word") or word.get("word") or "")
+        )
+        word["_source_text"] = (
+            str(leading.get("_source_text") or "")
+            + str(word.get("_source_text") or "")
+        )
+    words.append(word)
+
+
+def _extract_update(
+    update: FrontData | dict[str, Any],
+) -> tuple[list[dict[str, Any]], str, list[_SilenceBoundary], float]:
+    if isinstance(update, FrontData):
+        lines = update.lines
+        buffer_parts = (
+            update.buffer_diarization,
+            update.buffer_transcription,
+        )
+        remaining_time_diarization = update.remaining_time_diarization
     else:
-        seg_start = start_time
-        seg_end = start_time
-        duration = 0.0
+        lines = update.get("lines", [])
+        buffer_parts = (
+            update.get("buffer_diarization", ""),
+            update.get("buffer_transcription", ""),
+        )
+        remaining_time_diarization = update.get("remaining_time_diarization", 0.0)
+    buffer = _join_source_fragments(buffer_parts)
 
-    return {
-        "type": "Results",
-        "channel_index": [0, 1],
-        "duration": round(duration, 3),
-        "start": round(seg_start, 3),
-        "is_final": is_final,
-        "speech_final": speech_final,
-        "channel": {
-            "alternatives": [
-                {
-                    "transcript": transcript,
-                    "confidence": 0.0,
-                    "words": all_words,
-                }
-            ]
-        },
-    }
+    words: list[dict[str, Any]] = []
+    boundaries: list[_SilenceBoundary] = []
+    group_start = 0
+    for line in lines:
+        if isinstance(line, dict):
+            is_silence = line.get("speaker") == -2
+            start = _parse_time_str(line.get("start", 0.0))
+            end = _parse_time_str(line.get("end", start))
+        else:
+            is_silence = line.is_silence()
+            start = float(line.start or 0.0)
+            end = float(line.end or start)
+        if is_silence:
+            boundaries.append(
+                _SilenceBoundary(
+                    word_count=len(words),
+                    start=start,
+                    end=end,
+                )
+            )
+            group_start = len(words)
+        else:
+            for word in _line_to_words(line):
+                _append_word(words, word, group_start)
+    try:
+        diarization_lag = max(0.0, float(remaining_time_diarization or 0.0))
+    except (TypeError, ValueError):
+        diarization_lag = 0.0
+    return words, str(buffer), boundaries, diarization_lag
+
+
+def _word_identity(word: dict[str, Any]) -> str:
+    """Identity in transcript order; speaker and interim times may still move."""
+    return str(word.get("punctuated_word") or word.get("word") or "")
+
+
+def _is_wide_character(character: str) -> bool:
+    return unicodedata.east_asian_width(character) in {"W", "F"}
+
+
+def _join_source_fragments(fragments: list[str] | tuple[Any, ...]) -> str:
+    """Preserve explicit spacing and infer it only between bare Latin words."""
+    transcript = ""
+    for raw_fragment in fragments:
+        fragment = str(raw_fragment or "")
+        if not fragment:
+            continue
+        if (
+            transcript
+            and not fragment[0].isspace()
+            and transcript[-1].isalnum()
+            and fragment[0].isalnum()
+            and not _is_wide_character(transcript[-1])
+            and not _is_wide_character(fragment[0])
+        ):
+            transcript += " "
+        transcript += fragment
+    return transcript.strip()
+
+
+def _compose_transcript(words: list[dict[str, Any]]) -> str:
+    """Reconstruct source spacing while separating bare Latin word tokens."""
+    return _join_source_fragments(
+        [
+            str(
+                word.get("_source_text")
+                or word.get("punctuated_word")
+                or word.get("word")
+                or ""
+            )
+            for word in words
+        ]
+    )
+
+
+def _common_prefix_length(
+    left: list[dict[str, Any]],
+    right: list[dict[str, Any]],
+) -> int:
+    common = 0
+    for old, new in zip(left, right):
+        if _word_identity(old) != _word_identity(new):
+            break
+        common += 1
+    return common
 
 
 class DeepgramAdapter:
-    """Adapts WhisperLiveKit's FrontData stream to Deepgram's protocol."""
+    """Translate FrontData snapshots and sample-clock events to Deepgram JSON."""
 
-    def __init__(self, websocket: WebSocket):
+    def __init__(
+        self,
+        websocket: WebSocket,
+        options: Optional[DeepgramOptions] = None,
+        config: Any = None,
+    ) -> None:
         self.websocket = websocket
+        self.options = options or DeepgramOptions(
+            language=None,
+            interim_results=False,
+            vad_events=False,
+            endpointing_ms=_DEFAULT_ENDPOINTING_MS,
+            utterance_end_ms=None,
+        )
         self.request_id = str(uuid.uuid4())
-        self._prev_n_lines = 0
-        self._sent_lines = 0
-        self._last_word_end = 0.0
-        self._speech_started_sent = False
-        self._vad_events = False
+        self.model_uuid = str(uuid.uuid4())
+        self.backend = getattr(config, "backend", "whisper") if config else "whisper"
+        self._lock = asyncio.Lock()
 
-    async def send_metadata(self, config):
-        """Send initial Metadata message."""
-        backend = getattr(config, "backend", "whisper") if config else "whisper"
-        msg = {
+        self._observed_words: list[dict[str, Any]] = []
+        self._emitted_count = 0
+        self._latest_buffer = ""
+        self._remaining_time_diarization = 0.0
+        self._last_interim_signature: Optional[tuple[Any, ...]] = None
+        self._seen_boundaries: set[tuple[float, float]] = set()
+
+        self._audio_time = 0.0
+        self._active_silence_start: Optional[float] = None
+        self._pauses: dict[float, _PauseState] = {}
+        self._speech_started_timestamps: set[float] = set()
+        self._in_speech = False
+        self._utterance_open = False
+        self._last_speech_final_count = 0
+
+        self._last_final_word_end: Optional[float] = None
+        self._utterance_end_sent_for: Optional[float] = None
+
+    def _result_metadata(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "model_info": {
+                "name": self.backend,
+                "version": "whisperlivekit",
+                "arch": self.backend,
+            },
+            "model_uuid": self.model_uuid,
+        }
+
+    def _metadata_message(self, duration: float) -> dict[str, Any]:
+        return {
             "type": "Metadata",
+            "transaction_key": "deprecated",
             "request_id": self.request_id,
             "sha256": "",
             "created": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            "duration": 0,
+            "duration": round(max(0.0, duration), 3),
             "channels": 1,
-            "models": [backend],
-            "model_info": {
-                backend: {
-                    "name": backend,
-                    "version": "whisperlivekit",
-                }
-            },
+            "models": [self.backend],
         }
-        await self.websocket.send_json(msg)
 
-    async def process_update(self, front_data_dict: dict):
-        """Convert a FrontData dict into Deepgram messages and send them."""
-        lines = front_data_dict.get("lines", [])
-        buffer = front_data_dict.get("buffer_transcription", "")
+    async def send_metadata(self, duration: float = 0.0) -> None:
+        async with self._lock:
+            await self.websocket.send_json(self._metadata_message(duration))
 
-        speech_lines = [l for l in lines if l.get("speaker", 0) != -2]
-        n_speech = len(speech_lines)
+    async def send_summary_metadata(self, duration: float) -> None:
+        await self.send_metadata(duration)
 
-        # Detect new committed lines → emit as is_final=true results
-        if n_speech > self._sent_lines:
-            new_lines = speech_lines[self._sent_lines:]
-            result = _lines_to_result(new_lines, is_final=True, speech_final=True)
-            await self.websocket.send_json(result)
+    async def send_error(self, description: str) -> None:
+        async with self._lock:
+            await self.websocket.send_json(
+                {
+                    "type": "Error",
+                    "description": description,
+                    "request_id": self.request_id,
+                }
+            )
 
-            # Track last word end for UtteranceEnd
-            if result["channel"]["alternatives"][0]["words"]:
-                self._last_word_end = result["channel"]["alternatives"][0]["words"][-1]["end"]
+    def _result_message(
+        self,
+        words: list[dict[str, Any]],
+        *,
+        is_final: bool,
+        speech_final: bool,
+        transcript: Optional[str] = None,
+        from_finalize: bool = False,
+    ) -> dict[str, Any]:
+        if transcript is None:
+            transcript = _compose_transcript(words)
+        if words:
+            start = float(words[0]["start"])
+            end = float(words[-1]["end"])
+        else:
+            start = self._last_final_word_end or self._audio_time
+            end = start
+        return {
+            "type": "Results",
+            "channel_index": [0, 1],
+            "duration": round(max(0.0, end - start), 3),
+            "start": round(start, 3),
+            "is_final": is_final,
+            "speech_final": speech_final,
+            "from_finalize": from_finalize,
+            "channel": {
+                "alternatives": [
+                    {
+                        "transcript": transcript,
+                        "confidence": 0.0,
+                        "words": [
+                            {
+                                key: value
+                                for key, value in word.items()
+                                if not key.startswith("_")
+                            }
+                            for word in words
+                        ],
+                    }
+                ]
+            },
+            "metadata": self._result_metadata(),
+        }
 
-            self._sent_lines = n_speech
-
-        # Emit buffer as interim result (is_final=false)
-        elif buffer and buffer.strip():
-            # SpeechStarted event
-            if self._vad_events and not self._speech_started_sent:
-                await self.websocket.send_json({
-                    "type": "SpeechStarted",
-                    "channel_index": [0],
-                    "timestamp": 0.0,
-                })
-                self._speech_started_sent = True
-
-            # Create interim result from buffer
-            interim = {
-                "type": "Results",
-                "channel_index": [0, 1],
-                "duration": 0.0,
-                "start": self._last_word_end,
-                "is_final": False,
-                "speech_final": False,
-                "channel": {
-                    "alternatives": [
-                        {
-                            "transcript": buffer.strip(),
-                            "confidence": 0.0,
-                            "words": [],
-                        }
-                    ]
-                },
+    async def _send_speech_started(self, timestamp: float) -> None:
+        timestamp_key = round(float(timestamp), 6)
+        if (
+            not self.options.vad_events
+            or timestamp_key in self._speech_started_timestamps
+        ):
+            return
+        await self.websocket.send_json(
+            {
+                "type": "SpeechStarted",
+                "channel": [0, 1],
+                "timestamp": round(timestamp, 3),
             }
-            await self.websocket.send_json(interim)
+        )
+        self._speech_started_timestamps.add(timestamp_key)
 
-        # Detect silence → emit UtteranceEnd
-        silence_lines = [l for l in lines if l.get("speaker") == -2]
-        if silence_lines and n_speech > 0:
-            # Check if there's new silence after our last speech
-            for sil in silence_lines:
-                sil_start = _parse_time_str(sil.get("start", "0:00:00"))
-                if sil_start >= self._last_word_end:
-                    await self.websocket.send_json({
-                        "type": "UtteranceEnd",
-                        "channel": [0, 1],
-                        "last_word_end": round(self._last_word_end, 3),
-                    })
-                    self._speech_started_sent = False
-                    break
+    async def _send_utterance_end(self) -> None:
+        anchor = self._last_final_word_end
+        if anchor is None or self._utterance_end_sent_for == anchor:
+            return
+        await self.websocket.send_json(
+            {
+                "type": "UtteranceEnd",
+                "channel": [0, 1],
+                "last_word_end": round(anchor, 3),
+            }
+        )
+        self._utterance_end_sent_for = anchor
+
+    async def _maybe_send_gap_before(self, next_word_start: float) -> None:
+        if self.options.utterance_end_ms is None:
+            return
+        anchor = self._last_final_word_end
+        if anchor is None or self._utterance_end_sent_for == anchor:
+            return
+        threshold = self.options.utterance_end_ms / 1000.0
+        if next_word_start - anchor >= threshold:
+            await self._send_utterance_end()
+
+    async def _emit_final_until(
+        self,
+        target_count: int,
+        *,
+        speech_final: bool,
+        from_finalize: bool = False,
+        force: bool = False,
+    ) -> bool:
+        if self._remaining_time_diarization > 0.0 and not force:
+            return False
+        if not force:
+            pause_limit = self._pending_pause_limit()
+            if pause_limit is not None:
+                if not speech_final:
+                    return False
+                target_count = min(target_count, pause_limit)
+        target_count = min(max(target_count, self._emitted_count), len(self._observed_words))
+        words = [dict(word) for word in self._observed_words[self._emitted_count:target_count]]
+        if words:
+            await self._maybe_send_gap_before(float(words[0]["start"]))
+            await self.websocket.send_json(
+                self._result_message(
+                    words,
+                    is_final=True,
+                    speech_final=speech_final,
+                    from_finalize=from_finalize,
+                )
+            )
+            self._emitted_count = target_count
+            self._last_final_word_end = float(words[-1]["end"])
+            self._utterance_end_sent_for = None
+            self._utterance_open = not speech_final
+            if speech_final:
+                self._last_speech_final_count = target_count
+            self._last_interim_signature = None
+            await self._evaluate_utterance_end()
+            return True
+
+        if speech_final and target_count > self._last_speech_final_count:
+            await self.websocket.send_json(
+                self._result_message(
+                    [],
+                    is_final=True,
+                    speech_final=True,
+                    from_finalize=from_finalize,
+                )
+            )
+            self._last_speech_final_count = target_count
+            self._utterance_open = False
+            self._last_interim_signature = None
+            return True
+        return False
+
+    async def _send_interim(self) -> None:
+        if not self.options.interim_results:
+            return
+        words = [dict(word) for word in self._observed_words[self._emitted_count:]]
+        word_text = _compose_transcript(words)
+        transcript = _join_source_fragments(
+            [word_text, self._latest_buffer]
+        )
+        signature = (
+            tuple(
+                (
+                    _word_identity(word),
+                    word.get("start"),
+                    word.get("end"),
+                    word.get("speaker"),
+                    word.get("_source_text"),
+                )
+                for word in words
+            ),
+            self._latest_buffer.strip(),
+        )
+        if signature == self._last_interim_signature:
+            return
+        if not transcript and self._last_interim_signature is None:
+            return
+        if transcript:
+            self._utterance_open = True
+        await self.websocket.send_json(
+            self._result_message(
+                words,
+                is_final=False,
+                speech_final=False,
+                transcript=transcript,
+            )
+        )
+        self._last_interim_signature = signature
+
+    async def _evaluate_utterance_end(self) -> None:
+        if self.options.utterance_end_ms is None:
+            return
+        anchor = self._last_final_word_end
+        if anchor is None or self._utterance_end_sent_for == anchor:
+            return
+        threshold = self.options.utterance_end_ms / 1000.0
+        if self._audio_time - anchor < threshold:
+            return
+        if self._latest_buffer.strip():
+            return
+        pending = self._observed_words[self._emitted_count:]
+        if pending and float(pending[0]["start"]) - anchor < threshold:
+            return
+        await self._send_utterance_end()
+
+    @staticmethod
+    def _pause_key(timestamp: float) -> float:
+        return round(float(timestamp), 6)
+
+    async def _evaluate_pause(self, pause: _PauseState) -> None:
+        endpointing_ms = self.options.endpointing_ms
+        if endpointing_ms is None or pause.endpointed or not pause.transcription_ready:
+            return
+        pause_end = pause.end if pause.end is not None else self._audio_time
+        endpoint_due = (
+            pause_end - pause.start + 1e-9 >= endpointing_ms / 1000.0
+        )
+        if (
+            not endpoint_due
+            or self._oldest_pending_pause() is not pause
+            or self._latest_buffer.strip()
+            or self._remaining_time_diarization > 0.0
+        ):
+            return
+        target_count = self._pause_target_count(pause)
+        if target_count > self._last_speech_final_count:
+            await self._emit_final_until(
+                target_count,
+                speech_final=True,
+            )
+        pause.endpointed = True
+
+    def _pause_is_due(self, pause: _PauseState) -> bool:
+        if self.options.endpointing_ms is None:
+            return False
+        pause_end = pause.end if pause.end is not None else self._audio_time
+        return (
+            pause_end - pause.start + 1e-9
+            >= self.options.endpointing_ms / 1000.0
+        )
+
+    def _pause_target_count(self, pause: _PauseState) -> int:
+        target_count = 0
+        for index, word in enumerate(self._observed_words):
+            if float(word.get("start", 0.0)) >= pause.start:
+                break
+            target_count = index + 1
+        return target_count
+
+    def _oldest_pending_pause(self) -> Optional[_PauseState]:
+        for pause in self._pauses.values():
+            if not pause.endpointed and self._pause_is_due(pause):
+                return pause
+        return None
+
+    def _pending_pause_limit(self) -> Optional[int]:
+        pause = self._oldest_pending_pause()
+        return self._pause_target_count(pause) if pause is not None else None
+
+    async def _complete_pause_if_ready(self, pause: _PauseState) -> None:
+        await self._evaluate_pause(pause)
+        if pause.end is None:
+            return
+        pause_due = self._pause_is_due(pause)
+        if pause_due and (not pause.transcription_ready or not pause.endpointed):
+            return
+        if any(
+            earlier is not pause and earlier.start < pause.start
+            for earlier in self._pauses.values()
+        ):
+            return
+        if pause.resume_timestamp is not None:
+            await self._send_speech_started(pause.resume_timestamp)
+        self._pauses.pop(self._pause_key(pause.start), None)
+
+    async def _evaluate_timers(self) -> None:
+        for pause in list(self._pauses.values()):
+            await self._complete_pause_if_ready(pause)
+        await self._evaluate_utterance_end()
+
+    async def process_update(self, update: FrontData | dict[str, Any]) -> None:
+        """Reconcile one complete WLK snapshot and emit only protocol deltas."""
+        words, buffer, boundaries, diarization_lag = _extract_update(update)
+        async with self._lock:
+            previous = self._observed_words
+            common = _common_prefix_length(previous, words)
+            if common < self._emitted_count:
+                late_punctuation = []
+                punctuation_only_revision = len(words) >= self._emitted_count
+                if punctuation_only_revision:
+                    for index in range(common, self._emitted_count):
+                        old_word = previous[index]
+                        new_word = words[index]
+                        old_plain = str(old_word.get("word") or "")
+                        new_plain = str(new_word.get("word") or "")
+                        old_punctuated = str(
+                            old_word.get("punctuated_word") or old_plain
+                        )
+                        new_punctuated = str(
+                            new_word.get("punctuated_word") or new_plain
+                        )
+                        delta = (
+                            new_punctuated[len(old_punctuated):]
+                            if new_punctuated.startswith(old_punctuated)
+                            else ""
+                        )
+                        if (
+                            old_plain != new_plain
+                            or not delta
+                            or not all(
+                                character.isspace()
+                                or unicodedata.category(character).startswith("P")
+                                for character in delta
+                            )
+                        ):
+                            punctuation_only_revision = False
+                            break
+                        late_punctuation.append(delta)
+
+                if punctuation_only_revision:
+                    for delta in late_punctuation:
+                        await self.websocket.send_json(
+                            self._result_message(
+                                [],
+                                is_final=True,
+                                speech_final=False,
+                                transcript=delta.strip(),
+                            )
+                        )
+                    common = self._emitted_count
+                else:
+                    logger.error(
+                        "Deepgram source revised %d finalized words; keeping the immutable prefix.",
+                        self._emitted_count - common,
+                    )
+                    frozen = previous[:self._emitted_count]
+                    words = frozen + words[self._emitted_count:]
+                    common = self._emitted_count
+
+            changed = [
+                _word_identity(word) for word in previous
+            ] != [
+                _word_identity(word) for word in words
+            ]
+            self._observed_words = words
+            self._latest_buffer = buffer
+            self._remaining_time_diarization = diarization_lag
+            if previous and changed and common > self._emitted_count:
+                await self._emit_final_until(common, speech_final=False)
+
+            for boundary in boundaries:
+                key = (round(boundary.start, 3), round(boundary.end, 3))
+                if key in self._seen_boundaries:
+                    continue
+                if diarization_lag > 0.0:
+                    continue
+                self._seen_boundaries.add(key)
+                duration = max(0.0, boundary.end - boundary.start)
+                endpoint = (
+                    self.options.endpointing_ms is not None
+                    and duration >= self.options.endpointing_ms / 1000.0
+                )
+                if boundary.word_count < self._emitted_count:
+                    logger.debug(
+                        "Ignoring a late silence boundary behind the final cursor."
+                    )
+                    continue
+                await self._emit_final_until(
+                    boundary.word_count,
+                    speech_final=endpoint,
+                )
+
+            await self._evaluate_timers()
+            await self._send_interim()
+
+    async def process_stream_event(self, event: AudioStreamEvent) -> None:
+        """Apply a sample-clock event emitted by AudioProcessor."""
+        async with self._lock:
+            self._audio_time = max(self._audio_time, event.timestamp)
+            if event.kind == "silence_started":
+                self._active_silence_start = event.timestamp
+                self._pauses[self._pause_key(event.timestamp)] = _PauseState(
+                    start=event.timestamp,
+                )
+                self._in_speech = False
+            elif event.kind == "silence_transcription_ready":
+                pause = self._pauses.get(self._pause_key(event.timestamp))
+                if pause is not None:
+                    pause.transcription_ready = True
+                    await self._complete_pause_if_ready(pause)
+            elif event.kind == "speech_started":
+                pause = None
+                if self._active_silence_start is not None:
+                    pause = self._pauses.get(
+                        self._pause_key(self._active_silence_start)
+                    )
+                self._active_silence_start = None
+                if pause is None:
+                    if not self._in_speech:
+                        await self._send_speech_started(event.timestamp)
+                else:
+                    pause.end = event.timestamp
+                    pause.resume_timestamp = event.timestamp
+                    await self._complete_pause_if_ready(pause)
+                self._in_speech = True
+            elif event.kind != "audio_advanced":
+                logger.debug("Unknown audio stream event: %s", event.kind)
+            await self._evaluate_timers()
+
+    async def finish_stream(self, duration: float) -> None:
+        """Freeze any remaining suffix after AudioProcessor has fully drained."""
+        async with self._lock:
+            self._audio_time = max(self._audio_time, duration)
+            await self._emit_final_until(
+                len(self._observed_words),
+                speech_final=False,
+                force=True,
+            )
+            if self._latest_buffer.strip():
+                await self.websocket.send_json(
+                    self._result_message(
+                        [],
+                        is_final=True,
+                        speech_final=False,
+                        transcript=self._latest_buffer.strip(),
+                    )
+                )
+                self._latest_buffer = ""
+            self._last_interim_signature = None
 
 
-async def handle_deepgram_websocket(websocket: WebSocket, transcription_engine, config):
-    """Handle a Deepgram-compatible WebSocket session."""
+async def _reject_connection(websocket: WebSocket, description: str) -> None:
+    await websocket.accept()
+    try:
+        await websocket.send_json({"type": "Error", "description": description})
+    finally:
+        await websocket.close(code=4400, reason="invalid Deepgram session")
+
+
+async def handle_deepgram_websocket(
+    websocket: WebSocket,
+    transcription_engine: Any,
+    config: Any,
+) -> None:
+    """Handle one Deepgram-compatible WebSocket session."""
     from whisperlivekit.audio_processor import AudioProcessor
 
-    # Parse Deepgram query parameters
-    params = websocket.query_params
-    language = params.get("language", None)
-    vad_events = params.get("vad_events", "false").lower() == "true"
+    try:
+        options = DeepgramOptions.from_query_params(
+            websocket.query_params,
+            vac_enabled=bool(getattr(config, "vac", True)),
+        )
+    except ValueError as exc:
+        await _reject_connection(websocket, str(exc))
+        logger.warning("Deepgram-compatible WebSocket rejected: %s", exc)
+        return
 
+    event_queue: asyncio.Queue[Any] = asyncio.Queue()
     try:
         audio_processor = AudioProcessor(
             transcription_engine=transcription_engine,
-            language=language,
+            language=options.language,
+            mode="full",
+            stream_event_queue=event_queue,
+            pcm_input=options.pcm_input,
         )
-    except ValueError as e:
-        # Bad per-session parameters: answer the handshake, then close.
-        await websocket.accept()
-        try:
-            await websocket.send_json({"type": "Error", "description": str(e)})
-        finally:
-            await websocket.close(code=4400, reason="invalid session parameters")
-        logger.warning("Deepgram-compat WebSocket rejected: %s", e)
+    except ValueError as exc:
+        await _reject_connection(websocket, str(exc))
+        logger.warning("Deepgram-compatible WebSocket rejected: %s", exc)
         return
 
-    await websocket.accept()
-    logger.info("Deepgram-compat WebSocket opened")
+    adapter = DeepgramAdapter(websocket, options, config)
+    try:
+        await websocket.accept()
+        logger.info("Deepgram-compatible WebSocket opened")
+        await adapter.send_metadata()
+        results_generator = await audio_processor.create_tasks()
+    except Exception:
+        logger.exception("Deepgram-compatible WebSocket setup failed")
+        with suppress(Exception):
+            await adapter.send_error("Internal transcription setup error.")
+        with suppress(Exception):
+            await websocket.close(code=1011, reason="transcription setup failed")
+        with suppress(Exception):
+            await audio_processor.cleanup()
+        return
 
-    adapter = DeepgramAdapter(websocket)
-    adapter._vad_events = vad_events
+    delivered_errors: asyncio.Queue[str] = asyncio.Queue()
 
-    # Send metadata
-    await adapter.send_metadata(config)
-
-    results_generator = await audio_processor.create_tasks()
-
-    # Results consumer
-    async def handle_results():
+    async def consume_results() -> None:
         try:
             async for response in results_generator:
-                await adapter.process_update(response.to_dict())
-        except WebSocketDisconnect:
-            pass
-        except Exception as e:
-            logger.exception(f"Deepgram compat results error: {e}")
+                if (
+                    getattr(response, "error", "")
+                    or getattr(response, "status", "") == "error"
+                ):
+                    await event_queue.put(
+                        _StreamFailure(
+                            getattr(response, "error", "")
+                            or "Transcription failed."
+                        )
+                    )
+                    return
+                await event_queue.put(response)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Deepgram transcription result stream failed")
+            await event_queue.put(
+                _StreamFailure("Transcription result stream failed.")
+            )
 
-    results_task = asyncio.create_task(handle_results())
+    async def consume_events() -> None:
+        try:
+            while True:
+                event = await event_queue.get()
+                try:
+                    if event is _EVENTS_DONE:
+                        return
+                    if isinstance(event, _StreamFailure):
+                        await delivered_errors.put(event.description)
+                        return
+                    if isinstance(event, AudioStreamEvent):
+                        await adapter.process_stream_event(event)
+                    else:
+                        await adapter.process_update(event)
+                finally:
+                    event_queue.task_done()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Deepgram ordered event consumer failed")
+            await delivered_errors.put("Transcription event stream failed.")
 
-    # Audio / control message consumer
+    results_task = asyncio.create_task(consume_results())
+    events_task = asyncio.create_task(consume_events())
+    server_closed = False
+    client_disconnected = False
+
+    async def drain_and_close() -> None:
+        nonlocal server_closed
+        await audio_processor.process_audio(b"")
+        await results_task
+        await event_queue.put(_EVENTS_DONE)
+        await events_task
+        if not delivered_errors.empty():
+            description = delivered_errors.get_nowait()
+            delivered_errors.task_done()
+            await adapter.send_error(description)
+            await websocket.close(code=1011, reason="transcription failed")
+            server_closed = True
+            return
+        duration = audio_processor.total_pcm_samples / audio_processor.sample_rate
+        await adapter.finish_stream(duration)
+        await adapter.send_summary_metadata(duration)
+        await websocket.close(code=1000, reason="CloseStream complete")
+        server_closed = True
+
     try:
         while True:
-            try:
-                # Try to receive as text first (for control messages)
-                message = await asyncio.wait_for(
-                    websocket.receive(), timeout=30.0,
+            receive_task = asyncio.create_task(websocket.receive())
+            error_task = asyncio.create_task(delivered_errors.get())
+            done, pending = await asyncio.wait(
+                (receive_task, error_task),
+                timeout=30.0,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                await adapter.send_error(
+                    "No audio or KeepAlive message was received for 30 seconds."
                 )
-            except asyncio.TimeoutError:
-                # No data for 30s — close
+                await websocket.close(code=1011, reason="stream timeout")
+                server_closed = True
                 break
 
-            if "bytes" in message:
-                data = message["bytes"]
-                if data:
-                    await audio_processor.process_audio(data)
-                else:
-                    # Empty bytes = end of audio
-                    await audio_processor.process_audio(b"")
+            if error_task in done:
+                description = error_task.result()
+                delivered_errors.task_done()
+                receive_task.cancel()
+                await asyncio.gather(receive_task, return_exceptions=True)
+                await adapter.send_error(description)
+                await websocket.close(code=1011, reason="transcription failed")
+                server_closed = True
+                break
+
+            error_task.cancel()
+            await asyncio.gather(error_task, return_exceptions=True)
+            message = receive_task.result()
+
+            message_type = message.get("type")
+            if message_type == "websocket.disconnect":
+                client_disconnected = True
+                break
+
+            data = message.get("bytes")
+            if data is not None:
+                if not data:
+                    await adapter.send_error(
+                        "Empty binary frames are not an end-of-stream signal. "
+                        "Send a CloseStream control message."
+                    )
+                    await websocket.close(code=4400, reason="empty binary frame")
+                    server_closed = True
                     break
-            elif "text" in message:
-                try:
-                    ctrl = json.loads(message["text"])
-                    msg_type = ctrl.get("type", "")
+                await audio_processor.process_audio(data)
+                continue
 
-                    if msg_type == "CloseStream":
-                        await audio_processor.process_audio(b"")
-                        break
-                    elif msg_type == "Finalize":
-                        # Flush current audio — trigger end-of-utterance
-                        await audio_processor.process_audio(b"")
-                        results_generator = await audio_processor.create_tasks()
-                    elif msg_type == "KeepAlive":
-                        pass  # Just keep the connection alive
-                    else:
-                        logger.debug("Unknown Deepgram control message: %s", msg_type)
-                except json.JSONDecodeError:
-                    logger.warning("Invalid JSON control message")
-            else:
-                # WebSocket close
+            text = message.get("text")
+            if text is None:
+                client_disconnected = True
                 break
+            try:
+                control = json.loads(text)
+            except json.JSONDecodeError:
+                await adapter.send_error("Control messages must be valid JSON objects.")
+                continue
+
+            message_name = control.get("type", "") if isinstance(control, dict) else ""
+            if message_name == "KeepAlive":
+                continue
+            if message_name == "CloseStream":
+                await drain_and_close()
+                break
+            if message_name == "Finalize":
+                await adapter.send_error(
+                    "Finalize is not supported by WhisperLiveKit because its ASR "
+                    "flush is terminal. Send CloseStream to flush and close."
+                )
+                await websocket.close(code=4400, reason="Finalize is unsupported")
+                server_closed = True
+                break
+            logger.debug("Unknown Deepgram control message: %s", message_name)
 
     except WebSocketDisconnect:
-        logger.info("Deepgram-compat WebSocket disconnected")
-    except Exception as e:
-        logger.error(f"Deepgram-compat error: {e}", exc_info=True)
+        client_disconnected = True
+        logger.info("Deepgram-compatible WebSocket disconnected")
+    except Exception:
+        logger.exception("Deepgram-compatible WebSocket failed")
+        if not server_closed and not client_disconnected:
+            with suppress(Exception):
+                await adapter.send_error("Internal transcription error.")
+            with suppress(Exception):
+                await websocket.close(code=1011, reason="internal error")
+            server_closed = True
     finally:
-        if not results_task.done():
-            results_task.cancel()
-        try:
-            await results_task
-        except (asyncio.CancelledError, Exception):
-            pass
+        for task in (results_task, events_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(results_task, events_task, return_exceptions=True)
         await audio_processor.cleanup()
-        logger.info("Deepgram-compat WebSocket cleaned up")
+        logger.info("Deepgram-compatible WebSocket cleaned up")

--- a/whisperlivekit/timed_objects.py
+++ b/whisperlivekit/timed_objects.py
@@ -228,6 +228,14 @@ class ChangeSpeaker:
     speaker: int
     start: int
 
+
+@dataclass(frozen=True)
+class AudioStreamEvent:
+    """Sample-clock event exposed to protocol adapters."""
+
+    kind: str
+    timestamp: float
+
 @dataclass
 class State():
     """Unified state class for audio processing.


### PR DESCRIPTION
## Summary

- Rebuild the Deepgram-compatible stream adapter around immutable final cursors and one ordered event queue.
- Separate `is_final`, `speech_final`, VAD `SpeechStarted`, endpointing, and `UtteranceEnd` semantics.
- Preserve words, timestamps, speakers, punctuation, CJK spacing, and revisable interims across growing, replaced, split, and merged snapshots.
- Add sample-clock audio events and causal transcription barriers so pauses, diarization updates, errors, and shutdown cannot overtake their matching transcript state.
- Validate Deepgram query options and raw `linear16` input, reuse server authentication, and return protocol errors for unsupported or fatal paths.
- Update the API documentation for the supported compatibility subset and the tested `deepgram-sdk==7.7.0` client.
- Add comprehensive unit, handler, SDK, pause, diarization, EOF, and failure regressions.

## Root cause

The previous adapter treated each frontend snapshot as an append-only line list and conflated line finality with utterance endpointing. Results and audio events were consumed independently, so ASR, VAD, diarization, and shutdown could race. That caused dropped suffixes, repeated endpoint events, incorrect speakers, premature closure, and nonfunctional raw PCM examples.

## User impact

Deepgram clients now receive stable transcript deltas exactly once, endpoint events in causal order, final speaker corrections before publication, and a deterministic CloseStream drain. The documented raw PCM example works without requiring a global `--pcm-input` server setting.

## Validation

- `293 passed, 14 skipped` with the isolated CI command.
- `13 passed` in the real Whisper pipeline suite.
- `71 passed` for Deepgram on Python 3.11, 3.12, and 3.13 with `deepgram-sdk==7.7.0`.
- Thousands of adversarial pause, buffer, diarization, boundary, and readiness permutations.
- Real SDK loopback plus real Tiny model, LibriSpeech PCM, silence, endpoint, and CloseStream coverage.
- Ruff, locked dependency resolution, diff checks, wheel and sdist builds, Twine checks, and isolated wheel installation.

Fixes #413.