### PR TITLE
feat: add per-session decoder context

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Per-session WebSocket query parameters:
 |---|---|---|
 | `language` | `?language=fr` | transcription language for this session (one shared engine serves mixed-language sessions) |
 | `target_language` | `?target_language=de` | translation target for this session (server must run with `--target-language`) |
+| `context` | `?context=WhisperLiveKit%2C+Qwen3-ASR` | terminology, names, or phrase-list text used to condition this session; supported by Whisper-family and SimulStreaming backends |
 | `mode` | `?mode=diff` | incremental snapshot/diff protocol instead of resending the full state (experimental, for integrators building their own client, see `diff_protocol.py`); the bundled web UI uses `full` |
 | `token` | `?token=...` | API token when the server runs with `--api-token` (also accepted as an `Authorization: Bearer` header) |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,7 +24,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
 | `file`                   | file     | required | Audio file (any format ffmpeg can decode) |
 | `model`                  | string   | `""`     | Accepted but ignored (uses server's backend) |
 | `language`               | string   | `null`   | ISO 639-1 language code or null for auto-detection |
-| `prompt`                 | string   | `""`     | Accepted for compatibility, not yet used |
+| `prompt`                 | string   | `""`     | Per-request terminology or names used as decoder context (Whisper-family and SimulStreaming backends) |
 | `response_format`        | string   | `"json"` | `json`, `verbose_json`, `diarized_json`, `text`, `srt`, `vtt` |
 | `timestamp_granularities`| array    | `null`   | Accepted for compatibility |
 
@@ -159,6 +159,8 @@ async with deepgram.listen.v1.connect(
 **Supported Query Parameters:**
 
 - `language`: per-session source language
+- `context`: WLK extension for per-session terminology, names, or phrase-list
+  text used as decoder context
 - `model`: accepted for SDK compatibility; the server's configured WLK backend
   remains authoritative
 - `encoding=linear16`: select raw signed 16-bit PCM input; requires
@@ -389,11 +391,12 @@ ws://<host>:<port>/asr
 | Parameter  | Type   | Default  | Description |
 |------------|--------|----------|-------------|
 | `language` | string | _(none)_ | Per-session language override. ISO 639-1 code (e.g. `fr`, `en`) or `"auto"` for automatic detection. When omitted, uses the server-wide language setting. Multiple sessions with different languages work concurrently. |
+| `context` | string | _(none)_ | Terminology, names, or phrase-list text used as decoder context for this session. Maximum 1000 characters. |
 | `mode`     | string | `"full"` | Output mode. `"full"` sends complete state on every update. `"diff"` sends incremental diffs after an initial snapshot. |
 
 Example:
 ```
-ws://localhost:8000/asr?language=fr&mode=diff
+ws://localhost:8000/asr?language=fr&context=WhisperLiveKit%2C+Qwen3-ASR&mode=diff
 ```
 
 ### Connection Flow
@@ -417,7 +420,12 @@ Sent once, immediately after the connection is accepted.
 {
   "type": "config",
   "useAudioWorklet": true,
-  "mode": "full"
+  "mode": "full",
+  "context": {
+    "supported": true,
+    "maxCharacters": 1000,
+    "backend": "faster-whisper"
+  }
 }
 ```
 
@@ -426,6 +434,7 @@ Sent once, immediately after the connection is accepted.
 | `type`            | string | Always `"config"`. |
 | `useAudioWorklet` | bool   | `true` when the server expects PCM s16le 16kHz mono input (started with `--pcm-input`). `false` when the server expects encoded audio (decoded server-side via FFmpeg). |
 | `mode`            | string | `"full"` or `"diff"`, echoing the requested mode. |
+| `context`         | object | Decoder-context capability for the configured backend. |
 
 ### Transcription Update (full mode)
 
@@ -662,3 +671,22 @@ The `language` query parameter creates an isolated language context for the sess
 - Each WebSocket session can transcribe in a different language.
 - Sessions are thread-safe and do not interfere with each other.
 - Pass `"auto"` to use automatic language detection for the session regardless of the server-wide setting.
+
+## Per-Session Decoder Context
+
+The native and Deepgram-compatible WebSockets accept `context`; the
+OpenAI-compatible REST endpoint uses its standard `prompt` form field. The value
+is isolated per session and limited to 1000 characters.
+
+- LocalAgreement prepends the context to its rolling committed-transcript prompt
+  on every inference.
+- SimulStreaming adds it to a per-session copy of the static prompt, so it does
+  not scroll out as audio advances.
+- Whisper, Faster-Whisper, MLX Whisper, OpenAI API, and SimulStreaming support
+  this conditioning. FunASR, Canary, Qwen3, and Voxtral currently do not expose
+  a compatible prompt slot; requesting context with them returns HTTP 400 or a
+  WebSocket error with close code 4400 before audio processing starts.
+
+Context influences decoding but does not guarantee that a phrase will appear.
+N-best hypotheses, external scorer hooks, and public confidence streams remain
+separate capabilities and are not introduced by this option.

--- a/tests/test_backend_deep_bugs.py
+++ b/tests/test_backend_deep_bugs.py
@@ -847,6 +847,129 @@ def _import_basic_server(monkeypatch):
     return importlib.import_module("whisperlivekit.basic_server")
 
 
+@pytest.mark.asyncio
+async def test_native_websocket_passes_context_and_advertises_capability(monkeypatch):
+    from fastapi import WebSocketDisconnect
+
+    basic_server = _import_basic_server(monkeypatch)
+    processor_kwargs = []
+
+    class RecordingSocket:
+        query_params = {
+            "language": "fr",
+            "context": "WhisperLiveKit, Qwen3-ASR",
+        }
+        headers = {}
+
+        def __init__(self):
+            self.sent = []
+            self.accepted = False
+
+        async def accept(self):
+            self.accepted = True
+
+        async def send_json(self, message):
+            self.sent.append(message)
+
+        async def receive_bytes(self):
+            raise WebSocketDisconnect()
+
+    class EmptyProcessor:
+        def __init__(self, **kwargs):
+            processor_kwargs.append(kwargs)
+
+        async def create_tasks(self):
+            async def results():
+                if False:
+                    yield None
+
+            return results()
+
+        async def cleanup(self):
+            pass
+
+    asr = SimpleNamespace(backend_choice="faster-whisper")
+    monkeypatch.setattr(
+        basic_server,
+        "transcription_engine",
+        SimpleNamespace(
+            args=SimpleNamespace(
+                backend="faster-whisper",
+                backend_policy="localagreement",
+            ),
+            asr=asr,
+        ),
+    )
+    monkeypatch.setattr(basic_server, "_API_TOKEN", None)
+    monkeypatch.setattr(basic_server, "AudioProcessor", EmptyProcessor)
+    websocket = RecordingSocket()
+
+    await basic_server.websocket_endpoint(websocket)
+
+    assert websocket.accepted
+    assert processor_kwargs[0]["language"] == "fr"
+    assert processor_kwargs[0]["context"] == "WhisperLiveKit, Qwen3-ASR"
+    config_message = next(m for m in websocket.sent if m["type"] == "config")
+    assert config_message["context"] == {
+        "supported": True,
+        "maxCharacters": 1000,
+        "backend": "faster-whisper",
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_rest_rejects_unsupported_context_before_expensive_work(
+    monkeypatch,
+):
+    basic_server = _import_basic_server(monkeypatch)
+    expensive_calls = []
+
+    class UnreadUpload:
+        async def read(self):
+            expensive_calls.append("read")
+            return b"encoded audio"
+
+    async def forbidden_conversion(audio_bytes):
+        expensive_calls.append("convert")
+        return audio_bytes
+
+    class ForbiddenAudioProcessor:
+        def __init__(self, **kwargs):
+            expensive_calls.append("asr")
+
+    monkeypatch.setattr(
+        basic_server,
+        "transcription_engine",
+        SimpleNamespace(
+            args=SimpleNamespace(
+                backend="qwen3-streaming",
+                backend_policy="simulstreaming",
+            ),
+            asr=SimpleNamespace(),
+        ),
+    )
+    monkeypatch.setattr(basic_server, "_API_TOKEN", None)
+    monkeypatch.setattr(basic_server, "_convert_to_pcm", forbidden_conversion)
+    monkeypatch.setattr(basic_server, "AudioProcessor", ForbiddenAudioProcessor)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await basic_server.create_transcription(
+            request=SimpleNamespace(headers={}),
+            file=UnreadUpload(),
+            model="ignored",
+            language="en",
+            prompt="must not be ignored",
+            response_format="json",
+            timestamp_granularities=None,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "not supported by backend 'qwen3-streaming'" in exc_info.value.detail
+    assert expensive_calls == []
+
+
 def test_openai_rest_diarized_json_preserves_speaker_labels(monkeypatch):
     basic_server = _import_basic_server(monkeypatch)
 
@@ -1109,6 +1232,7 @@ async def test_openai_rest_empty_result_uses_requested_formatter(
 
     basic_server = _import_basic_server(monkeypatch)
     formatted_inputs = []
+    processor_kwargs = []
     real_formatter = basic_server._format_openai_response
 
     class EncodedUpload:
@@ -1124,6 +1248,7 @@ async def test_openai_rest_empty_result_uses_requested_formatter(
 
     class EmptyAudioProcessor:
         def __init__(self, **kwargs):
+            processor_kwargs.append(kwargs)
             self.is_pcm_input = False
 
         async def create_tasks(self):
@@ -1154,12 +1279,13 @@ async def test_openai_rest_empty_result_uses_requested_formatter(
         file=EncodedUpload(),
         model="ignored",
         language="en",
-        prompt="",
+        prompt="WhisperLiveKit, Qwen3-ASR",
         response_format=response_format,
         timestamp_granularities=None,
     )
 
     assert len(formatted_inputs) == 1
+    assert processor_kwargs[0]["context"] == "WhisperLiveKit, Qwen3-ASR"
     assert isinstance(formatted_inputs[0], FrontData)
     assert formatted_inputs[0].lines == []
     if isinstance(expected_body, dict):

--- a/tests/test_deepgram_compat.py
+++ b/tests/test_deepgram_compat.py
@@ -119,6 +119,15 @@ def test_linear16_options_select_exact_pcm_contract():
     assert options.pcm_input is True
 
 
+def test_context_option_is_preserved_for_the_session_processor():
+    options = DeepgramOptions.from_query_params(
+        {"context": "WhisperLiveKit, Qwen3-ASR"},
+        vac_enabled=True,
+    )
+
+    assert options.context == "WhisperLiveKit, Qwen3-ASR"
+
+
 @pytest.mark.parametrize(
     ("params", "message"),
     [
@@ -1084,7 +1093,7 @@ async def test_close_stream_drains_results_before_summary_and_close(monkeypatch)
     DelayedFinalProcessor.instances = []
     monkeypatch.setattr(audio_processor_module, "AudioProcessor", DelayedFinalProcessor)
     websocket = RecordingWebSocket(
-        {"endpointing": "false"},
+        {"endpointing": "false", "context": "WhisperLiveKit, Qwen3-ASR"},
         [{"type": "websocket.receive", "text": '{"type":"CloseStream"}'}],
     )
 
@@ -1095,6 +1104,7 @@ async def test_close_stream_drains_results_before_summary_and_close(monkeypatch)
     )
 
     processor = DelayedFinalProcessor.instances[0]
+    assert processor.kwargs["context"] == "WhisperLiveKit, Qwen3-ASR"
     assert processor.create_tasks_calls == 1
     assert processor.processed == [b""]
     assert processor.cleanup_called

--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -1,0 +1,202 @@
+"""Per-session decoder-context regressions for issue #421."""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from whisperlivekit.session_asr_proxy import (
+    MAX_SESSION_CONTEXT_CHARS,
+    SessionASRProxy,
+    normalize_session_context,
+    session_context_capability,
+)
+
+
+class _RecordingASR:
+    sep = " "
+    backend_choice = "faster-whisper"
+    confidence_validation = False
+    tokenizer = None
+    buffer_trimming = "segment"
+    buffer_trimming_sec = 15.0
+
+    def __init__(self, language="en"):
+        self.original_language = language
+        self.calls = []
+
+    def transcribe(self, audio, init_prompt=""):
+        self.calls.append((self.original_language, init_prompt, audio))
+        return []
+
+
+def test_context_is_normalized_and_bounded():
+    assert normalize_session_context(None) is None
+    assert normalize_session_context("  WhisperLiveKit, Qwen3-ASR  ") == (
+        "WhisperLiveKit, Qwen3-ASR"
+    )
+    assert normalize_session_context("   ") is None
+
+    with pytest.raises(ValueError, match="at most 1000"):
+        normalize_session_context("x" * (MAX_SESSION_CONTEXT_CHARS + 1))
+    with pytest.raises(ValueError, match="NUL"):
+        normalize_session_context("valid\x00invalid")
+
+
+def test_localagreement_context_is_stable_and_session_isolated():
+    shared = _RecordingASR(language="en")
+    french = SessionASRProxy(
+        shared,
+        "fr",
+        context="WhisperLiveKit, CTranslate2",
+    )
+    auto = SessionASRProxy(shared, "auto", context="Qwen3-ASR")
+
+    french.transcribe("audio-one", init_prompt="rolling history")
+    auto.transcribe("audio-two", init_prompt="other history")
+
+    assert shared.calls == [
+        ("fr", "WhisperLiveKit, CTranslate2\nrolling history", "audio-one"),
+        (None, "Qwen3-ASR\nother history", "audio-two"),
+    ]
+    assert shared.original_language == "en"
+
+
+def test_context_only_proxy_keeps_server_language():
+    shared = _RecordingASR(language="de")
+    proxy = SessionASRProxy(shared, context="Fachbegriff")
+
+    proxy.transcribe("audio")
+
+    assert shared.calls == [("de", "Fachbegriff", "audio")]
+    assert shared.original_language == "de"
+
+
+def test_simulstreaming_context_uses_an_isolated_static_config(monkeypatch):
+    import whisperlivekit.simul_whisper as simul_module
+    from whisperlivekit.core import online_factory
+
+    class FakeProcessor:
+        def __init__(self, asr):
+            self.asr = asr
+
+    monkeypatch.setattr(simul_module, "SimulStreamingOnlineProcessor", FakeProcessor)
+    shared = _RecordingASR(language="en")
+    shared.cfg = SimpleNamespace(
+        language="en",
+        static_init_prompt="global terminology",
+    )
+    shared.use_full_mlx = False
+    args = SimpleNamespace(
+        backend="faster-whisper",
+        backend_policy="simulstreaming",
+    )
+
+    processor = online_factory(
+        args,
+        shared,
+        language="fr",
+        context="session terminology",
+    )
+
+    assert processor.asr.cfg.language == "fr"
+    assert processor.asr.cfg.static_init_prompt == (
+        "global terminology\nsession terminology"
+    )
+    assert shared.cfg.language == "en"
+    assert shared.cfg.static_init_prompt == "global terminology"
+
+
+@pytest.mark.parametrize("backend", ["funasr", "canary", "qwen3-streaming", "voxtral"])
+def test_unsupported_backends_reject_context_before_audio_processing(backend):
+    from whisperlivekit.core import online_factory
+
+    asr = _RecordingASR()
+    asr.backend_choice = backend
+    # Explicit backends bypass the generic SimulStreaming route even when the
+    # server-wide policy retains its default value.
+    args = SimpleNamespace(backend=backend, backend_policy="simulstreaming")
+
+    with pytest.raises(ValueError, match=f"not supported by backend {backend!r}"):
+        online_factory(args, asr, context="must not be ignored")
+
+    capability = session_context_capability(args, asr)
+    assert capability == {
+        "supported": False,
+        "maxCharacters": 1000,
+        "backend": backend,
+    }
+
+
+def test_localagreement_factory_exposes_context_capability_and_proxy():
+    from whisperlivekit.core import online_factory
+    from whisperlivekit.local_agreement.online_asr import OnlineASRProcessor
+
+    asr = _RecordingASR()
+    args = SimpleNamespace(
+        backend="faster-whisper",
+        backend_policy="localagreement",
+    )
+
+    processor = online_factory(args, asr, context="domain phrase")
+
+    assert isinstance(processor, OnlineASRProcessor)
+    assert isinstance(processor.asr, SessionASRProxy)
+    processor.asr.transcribe("audio", init_prompt="history")
+    assert asr.calls[-1][1] == "domain phrase\nhistory"
+    assert session_context_capability(args, asr)["supported"] is True
+
+    plain_processor = online_factory(args, asr)
+    assert isinstance(plain_processor.asr, SessionASRProxy)
+    assert plain_processor.asr._lock is processor.asr._lock
+
+
+def test_plain_session_cannot_observe_another_sessions_language_override():
+    from whisperlivekit.core import online_factory
+
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+
+    class BlockingASR(_RecordingASR):
+        def transcribe(self, audio, init_prompt=""):
+            observed_language = self.original_language
+            if audio == "first":
+                first_entered.set()
+                assert release_first.wait(timeout=2)
+            else:
+                second_entered.set()
+            self.calls.append((audio, observed_language, init_prompt))
+            return []
+
+    shared = BlockingASR(language="en")
+    args = SimpleNamespace(
+        backend="faster-whisper",
+        backend_policy="localagreement",
+    )
+    french = online_factory(args, shared, language="fr", context="termes")
+    plain = online_factory(args, shared)
+
+    first = threading.Thread(
+        target=french.asr.transcribe,
+        args=("first",),
+        kwargs={"init_prompt": "historique"},
+    )
+    second = threading.Thread(target=plain.asr.transcribe, args=("second",))
+    first.start()
+    assert first_entered.wait(timeout=2)
+    second.start()
+
+    # The plain session participates in the shared lock and cannot enter while
+    # the French override is installed on the shared backend.
+    assert not second_entered.wait(timeout=0.05)
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert shared.calls == [
+        ("first", "fr", "termes\nhistorique"),
+        ("second", "en", ""),
+    ]

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -101,6 +101,7 @@ class AudioProcessor:
         """Initialize the audio processor with configuration, models, and state."""
         # Extract per-session options before passing to TranscriptionEngine
         session_language = kwargs.pop('language', None)
+        session_context = kwargs.pop('context', None)
         self.stream_event_queue = kwargs.pop('stream_event_queue', None)
         self._stream_events_after_snapshot = (
             asyncio.Queue() if self.stream_event_queue is not None else None
@@ -199,7 +200,12 @@ class AudioProcessor:
         self.diarization: Optional[Any] = None
 
         if self.args.transcription:
-            self.transcription = online_factory(self.args, models.asr, language=session_language)
+            self.transcription = online_factory(
+                self.args,
+                models.asr,
+                language=session_language,
+                context=session_context,
+            )
             self.sep = self.transcription.asr.sep
         if self.args.diarization:
             self.diarization = online_diarization_factory(self.args, models.diarization_model)

--- a/whisperlivekit/basic_server.py
+++ b/whisperlivekit/basic_server.py
@@ -104,6 +104,7 @@ async def websocket_endpoint(websocket: WebSocket):
     session_language = websocket.query_params.get("language", None)
     mode = websocket.query_params.get("mode", "full")
     session_target_language = websocket.query_params.get("target_language", None)
+    session_context = websocket.query_params.get("context", None)
 
     try:
         audio_processor = AudioProcessor(
@@ -111,6 +112,7 @@ async def websocket_endpoint(websocket: WebSocket):
             language=session_language,
             mode=mode,
             target_language=session_target_language,
+            context=session_context,
         )
     except ValueError as e:
         # Bad per-session parameters (e.g. a language the backend does not
@@ -124,9 +126,10 @@ async def websocket_endpoint(websocket: WebSocket):
         return
     await websocket.accept()
     logger.info(
-        "WebSocket connection opened.%s%s",
+        "WebSocket connection opened.%s%s%s",
         f" language={session_language}" if session_language else "",
         f" target_language={session_target_language}" if session_target_language else "",
+        f" context_chars={len(session_context)}" if session_context else "",
     )
     diff_tracker = None
     if mode == "diff":
@@ -135,7 +138,17 @@ async def websocket_endpoint(websocket: WebSocket):
         logger.info("Client requested diff mode")
 
     try:
-        await websocket.send_json({"type": "config", "useAudioWorklet": bool(config.pcm_input), "mode": mode})
+        from whisperlivekit.session_asr_proxy import session_context_capability
+
+        await websocket.send_json({
+            "type": "config",
+            "useAudioWorklet": bool(config.pcm_input),
+            "mode": mode,
+            "context": session_context_capability(
+                transcription_engine.args,
+                transcription_engine.asr,
+            ),
+        })
     except Exception as e:
         logger.warning(f"Failed to send config to client: {e}")
 
@@ -422,7 +435,8 @@ async def create_transcription(
 
     Implements the compatibility-oriented subset documented in docs/API.md.
     The `model` parameter is accepted but ignored (uses the server's configured
-    backend); `prompt` is likewise accepted but has no effect.
+    backend). `prompt` supplies decoder context for backends that expose text
+    conditioning and returns HTTP 400 for backends that do not.
     """
     global transcription_engine
     from fastapi import HTTPException
@@ -444,6 +458,19 @@ async def create_transcription(
             detail=_DIARIZED_JSON_REQUIRES_DIARIZATION,
         )
 
+    # Validate decoder context before reading or converting a potentially large
+    # upload. AudioProcessor validates again at the session factory boundary.
+    from whisperlivekit.session_asr_proxy import validate_session_context
+
+    try:
+        prompt = validate_session_context(
+            getattr(transcription_engine, "args", config),
+            getattr(transcription_engine, "asr", None),
+            prompt,
+        ) or ""
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
     audio_bytes = await file.read()
     if not audio_bytes:
         raise HTTPException(status_code=400, detail="Empty audio file")
@@ -463,6 +490,7 @@ async def create_transcription(
         processor = AudioProcessor(
             transcription_engine=transcription_engine,
             language=language,
+            context=prompt,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/whisperlivekit/core.py
+++ b/whisperlivekit/core.py
@@ -392,7 +392,7 @@ class _ASRTokenNormalizer:
             return wrapped
         return attr
 
-def online_factory(args, asr, language=None):
+def online_factory(args, asr, language=None, context=None):
     """Create an online ASR processor for a session.
 
     Args:
@@ -401,8 +401,16 @@ def online_factory(args, asr, language=None):
         language: Optional per-session language override (e.g. "en", "fr", "auto").
             If provided and the backend supports it, transcription will use
             this language instead of the server-wide default.
+        context: Optional terminology, names, or other text conditioning for
+            this session. Unsupported backends reject it explicitly.
     """
+    from whisperlivekit.session_asr_proxy import (
+        SessionASRProxy,
+        validate_session_context,
+    )
+
     backend = getattr(args, 'backend', None)
+    context = validate_session_context(args, asr, context)
     # Canary carries its own per-session wrapper (CanarySessionASR with auto-detect),
     # so it returns here before the generic SessionASRProxy wrap to avoid double-wrapping.
     if backend == "canary":
@@ -418,8 +426,10 @@ def online_factory(args, asr, language=None):
         )
         return OnlineASRProcessor(wrapped)
 
-    # Wrap the shared ASR with a per-session language if requested
-    if language is not None:
+    # Wrap the shared ASR with per-session language and decoder context. For
+    # SimulStreaming, the proxy also exposes an isolated cfg copy consumed by
+    # SimulStreamingOnlineProcessor at construction time.
+    if language is not None or context is not None:
         if getattr(args, "backend", None) == "funasr":
             from whisperlivekit.config import FUNASR_LANGUAGES
 
@@ -428,8 +438,14 @@ def online_factory(args, asr, language=None):
                 raise ValueError(
                     f"FunASR SenseVoiceSmall supports only: {supported}."
                 )
-        from whisperlivekit.session_asr_proxy import SessionASRProxy
-        asr = SessionASRProxy(asr, language)
+        asr = SessionASRProxy(
+            asr,
+            language,
+            context=context,
+            simulstreaming=(
+                getattr(args, "backend_policy", None) == "simulstreaming"
+            ),
+        )
 
     if backend == "qwen3-streaming":
         from whisperlivekit.qwen3_streaming import Qwen3StreamingOnlineProcessor
@@ -458,10 +474,18 @@ def online_factory(args, asr, language=None):
         return VoxtralHFStreamingOnlineProcessor(asr)
     if backend == "funasr":
         from whisperlivekit.funasr_backend import FunASROnlineASRProcessor
+        if not isinstance(asr, SessionASRProxy):
+            asr = SessionASRProxy(asr)
         return FunASROnlineASRProcessor(asr)
-    if args.backend_policy == "simulstreaming":
+    if getattr(args, "backend_policy", None) == "simulstreaming":
         from whisperlivekit.simul_whisper import SimulStreamingOnlineProcessor
         return SimulStreamingOnlineProcessor(asr)
+    if not isinstance(asr, SessionASRProxy):
+        # Every shared LocalAgreement backend participates in the same lock,
+        # including sessions that use the server-wide language. Otherwise a
+        # plain session could race with a language-overriding proxy and observe
+        # its temporary ``original_language`` value.
+        asr = SessionASRProxy(asr)
     return OnlineASRProcessor(asr)
 
 

--- a/whisperlivekit/deepgram_compat.py
+++ b/whisperlivekit/deepgram_compat.py
@@ -87,6 +87,7 @@ class DeepgramOptions:
     endpointing_ms: Optional[int]
     utterance_end_ms: Optional[int]
     pcm_input: Optional[bool] = None
+    context: Optional[str] = None
 
     @classmethod
     def from_query_params(
@@ -157,6 +158,7 @@ class DeepgramOptions:
             endpointing_ms=endpointing_ms,
             utterance_end_ms=utterance_end_ms,
             pcm_input=True if encoding == "linear16" else None,
+            context=params.get("context"),
         )
 
 
@@ -940,6 +942,7 @@ async def handle_deepgram_websocket(
             mode="full",
             stream_event_queue=event_queue,
             pcm_input=options.pcm_input,
+            context=options.context,
         )
     except ValueError as exc:
         await _reject_connection(websocket, str(exc))

--- a/whisperlivekit/session_asr_proxy.py
+++ b/whisperlivekit/session_asr_proxy.py
@@ -1,41 +1,158 @@
-"""Per-session ASR proxy for language override.
+"""Per-session ASR proxy for language and decoder-context overrides.
 
 Wraps a shared ASR backend so that each WebSocket session can use a
-different transcription language without modifying the shared instance.
+different transcription language and prompt context without modifying the
+shared instance.
 """
 
+import copy
 import threading
+from typing import Optional
+
+MAX_SESSION_CONTEXT_CHARS = 1000
+_PROMPT_BACKENDS = frozenset({
+    "faster-whisper",
+    "mlx-whisper",
+    "openai-api",
+    "whisper",
+})
+_NON_PROMPT_BACKENDS = frozenset({
+    "canary",
+    "funasr",
+    "qwen3-streaming",
+    "qwen3-vllm",
+    "qwen3-vllm-metal",
+    "voxtral",
+    "voxtral-mlx",
+})
+
+
+def normalize_session_context(context: Optional[str]) -> Optional[str]:
+    """Normalize a user-supplied prompt or reject an unsafe model payload."""
+    if context is None:
+        return None
+    normalized = str(context).strip()
+    if not normalized:
+        return None
+    if len(normalized) > MAX_SESSION_CONTEXT_CHARS:
+        raise ValueError(
+            f"context must be at most {MAX_SESSION_CONTEXT_CHARS} characters."
+        )
+    if "\x00" in normalized:
+        raise ValueError("context must not contain NUL characters.")
+    return normalized
+
+
+def _backend_name(args, asr) -> str:
+    return str(
+        getattr(asr, "backend_choice", None)
+        or getattr(args, "backend", None)
+        or asr.__class__.__name__
+    )
+
+
+def supports_session_context(args, asr) -> bool:
+    """Return whether this configured ASR can consume text conditioning."""
+    backend = _backend_name(args, asr)
+    if backend in _NON_PROMPT_BACKENDS:
+        return False
+    if getattr(args, "backend_policy", None) == "simulstreaming":
+        return True
+    return backend in _PROMPT_BACKENDS
+
+
+def session_context_capability(args, asr) -> dict:
+    """Return a protocol-friendly description of session context support."""
+    return {
+        "supported": supports_session_context(args, asr),
+        "maxCharacters": MAX_SESSION_CONTEXT_CHARS,
+        "backend": _backend_name(args, asr),
+    }
+
+
+def validate_session_context(args, asr, context: Optional[str]) -> Optional[str]:
+    """Normalize context and fail explicitly when the backend cannot use it."""
+    normalized = normalize_session_context(context)
+    if normalized is not None and not supports_session_context(args, asr):
+        backend = _backend_name(args, asr)
+        raise ValueError(
+            f"Session context is not supported by backend {backend!r}. "
+            "Use Whisper, Faster-Whisper, MLX Whisper, OpenAI API, or "
+            "SimulStreaming."
+        )
+    return normalized
+
+
+def merge_session_context(context: Optional[str], prompt: Optional[str]) -> str:
+    """Keep terminology context stable while preserving rolling ASR history."""
+    parts = [part for part in (context, prompt) if part]
+    return "\n".join(parts)
 
 
 class SessionASRProxy:
-    """Wraps a shared ASR backend with a per-session language override.
+    """Wrap a shared ASR backend with isolated language and prompt context.
 
     The proxy delegates all attribute access to the wrapped ASR except
-    ``transcribe()``, which temporarily overrides ``original_language``
-    on the shared ASR (under a lock) so the correct language is used.
+    ``transcribe()``, which prepends session context and temporarily overrides
+    ``original_language`` on the shared ASR (under a lock) so the correct
+    language is used.
+
+    SimulStreaming does not call ``transcribe()``. Its online decoder reads a
+    config object when the session is created, so the proxy exposes a shallow
+    per-session copy of that config with an isolated language and static prompt.
 
     Thread-safety: a per-ASR lock serializes ``transcribe()`` calls,
     which is acceptable because model inference is typically GPU-bound
     and cannot be parallelized anyway.
     """
 
-    def __init__(self, asr, language: str):
+    def __init__(
+        self,
+        asr,
+        language: Optional[str] = None,
+        *,
+        context: Optional[str] = None,
+        simulstreaming: bool = False,
+    ):
         object.__setattr__(self, '_asr', asr)
-        object.__setattr__(self, '_session_language', None if language == "auto" else language)
+        object.__setattr__(
+            self,
+            '_session_language',
+            None if language in (None, "auto") else language,
+        )
+        object.__setattr__(self, '_override_language', language is not None)
+        object.__setattr__(self, '_session_context', context)
+        object.__setattr__(self, '_session_cfg', None)
+
+        if simulstreaming:
+            cfg = copy.copy(asr.cfg)
+            if language is not None:
+                cfg.language = language
+            if context is not None:
+                cfg.static_init_prompt = merge_session_context(
+                    getattr(cfg, "static_init_prompt", None),
+                    context,
+                )
+            object.__setattr__(self, '_session_cfg', cfg)
+
         # Attach a shared lock to the ASR instance (created once, reused by all proxies)
         if not hasattr(asr, '_session_lock'):
             asr._session_lock = threading.Lock()
         object.__setattr__(self, '_lock', asr._session_lock)
 
     def __getattr__(self, name):
+        if name == "cfg" and self._session_cfg is not None:
+            return self._session_cfg
         return getattr(self._asr, name)
 
     def transcribe(self, audio, init_prompt=""):
-        """Call the backend's transcribe with the session's language."""
+        """Call the backend with this session's language and stable context."""
+        prompt = merge_session_context(self._session_context, init_prompt)
         with self._lock:
             saved = self._asr.original_language
-            self._asr.original_language = self._session_language
+            if self._override_language:
+                self._asr.original_language = self._session_language
             try:
-                return self._asr.transcribe(audio, init_prompt=init_prompt)
+                return self._asr.transcribe(audio, init_prompt=prompt)
             finally:
                 self._asr.original_language = saved

--- a/whisperlivekit/test_client.py
+++ b/whisperlivekit/test_client.py
@@ -28,6 +28,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
+from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
 
@@ -330,6 +331,10 @@ def main():
         "--language", "-l", default=None,
         help="Override transcription language for this session (e.g. en, fr, auto)",
     )
+    parser.add_argument(
+        "--context", default=None,
+        help="Terminology or names used as decoder context for this session",
+    )
     parser.add_argument("--json", action="store_true", help="Output raw JSON responses")
     parser.add_argument(
         "--diff", action="store_true",
@@ -368,12 +373,14 @@ def main():
     url = args.url
     params = []
     if args.language:
-        params.append(f"language={args.language}")
+        params.append(("language", args.language))
+    if args.context:
+        params.append(("context", args.context))
     if args.diff:
-        params.append("mode=diff")
+        params.append(("mode", "diff"))
     if params:
         sep = "&" if "?" in url else "?"
-        url = f"{url}{sep}{'&'.join(params)}"
+        url = f"{url}{sep}{urlencode(params)}"
 
     result = asyncio.run(transcribe_audio(
         audio_path=str(audio_path),


### PR DESCRIPTION
## Summary

- add an isolated `context` query option to the native and Deepgram-compatible WebSockets
- make the OpenAI-compatible REST `prompt` field condition the decoder instead of being silently ignored
- keep context stable alongside LocalAgreement rolling history and in a per-session SimulStreaming static prompt
- advertise native WebSocket context capability and reject unsupported backends before audio processing
- cap user context at 1000 characters and preserve server-wide prompts without cross-session mutation
- make every shared LocalAgreement Whisper/FunASR session participate in the language-override lock, closing the pre-existing race with default-language sessions
- document the capability and add `--context` to the headless test client with correct URL encoding

## Backend contract

Supported: Whisper, Faster-Whisper, MLX Whisper, OpenAI API, and SimulStreaming.

FunASR, Canary, Qwen3, and Voxtral do not currently expose a compatible prompt-conditioning slot. They return HTTP 400 or a WebSocket error/4400 when context is requested instead of silently ignoring it.

This intentionally does not add N-best hypotheses, shallow-fusion hooks, or a public confidence stream; those require separate backend-specific decoding contracts.

## Validation

- `uv run --frozen ruff check .`
- `uv lock --check`
- `uv run --frozen --extra test pytest -q tests/ --ignore=tests/test_pipeline.py` — 304 passed, 15 skipped
- focused REST/native WebSocket/Deepgram/context suite — 136 passed
- isolated wheel and sdist build plus `twine check` — passed

Closes #421.