### PR TITLE
fix: strip transcription-only params from OpenAI translation requests

### DIFF
--- a/tests/test_backend_deep_bugs.py
+++ b/tests/test_backend_deep_bugs.py
@@ -623,6 +623,36 @@ def test_openai_api_asr_initializes_transcribe_kwargs_and_routes_tasks(monkeypat
     assert len(translations.calls) == 1
     assert translations.calls[0]["prompt"] == "previous context"
 
+    # translations.create() rejects unrecognized keyword arguments, so the
+    # transcription-only params must not be forwarded to it.
+    assert "timestamp_granularities" not in translations.calls[0]
+    assert "language" not in translations.calls[0]
+    assert transcriptions.calls[0]["timestamp_granularities"] == ["word", "segment"]
+    assert transcriptions.calls[0]["language"] == "en"
+
+
+def test_openai_api_asr_ts_words_and_segments_end_ts_handle_translation_responses():
+    from whisperlivekit.local_agreement.backends import OpenaiApiASR
+
+    asr = OpenaiApiASR.__new__(OpenaiApiASR)
+    asr.use_vad_opt = False
+
+    # Translation responses (openai `audio.translations.create`) carry
+    # segments but no word-level timestamps.
+    translation_response = SimpleNamespace(
+        segments=[
+            SimpleNamespace(start=0.0, end=1.2, text="hello", no_speech_prob=0.1),
+            SimpleNamespace(start=1.2, end=2.5, text="world", no_speech_prob=0.1),
+        ]
+    )
+
+    tokens = asr.ts_words(translation_response)
+    assert [t.text for t in tokens] == ["hello", "world"]
+    assert [t.start for t in tokens] == [0.0, 1.2]
+    assert [t.end for t in tokens] == [1.2, 2.5]
+
+    assert asr.segments_end_ts(translation_response) == [1.2, 2.5]
+
 
 def test_tokens_alignment_prunes_long_running_history():
     from whisperlivekit.timed_objects import ASRToken, Segment, SpeakerSegment, State, TimedText

--- a/whisperlivekit/local_agreement/backends.py
+++ b/whisperlivekit/local_agreement/backends.py
@@ -240,14 +240,19 @@ class OpenaiApiASR(ASRBase):
         """
         Converts OpenAI API response words into ASRToken objects while
         optionally skipping words that fall into no-speech segments.
+        Translation responses have no word-level timestamps, so we fall
+        back to segment-level tokens in that case.
         """
         no_speech_segments = []
         if self.use_vad_opt:
             for segment in segments.segments:
                 if segment.no_speech_prob > 0.8:
                     no_speech_segments.append((segment.start, segment.end))
+        words = getattr(segments, "words", None)
+        if words is None:
+            return [ASRToken(segment.start, segment.end, segment.text) for segment in segments.segments]
         tokens = []
-        for word in segments.words:
+        for word in words:
             start = word.start
             end = word.end
             if any(s[0] <= start <= s[1] for s in no_speech_segments):
@@ -256,7 +261,10 @@ class OpenaiApiASR(ASRBase):
         return tokens
 
     def segments_end_ts(self, res) -> List[float]:
-        return [s.end for s in res.words]
+        words = getattr(res, "words", None)
+        if words is None:
+            return [s.end for s in res.segments]
+        return [s.end for s in words]
 
     def transcribe(self, audio_data, prompt=None, *args, **kwargs):
         prompt = prompt or kwargs.get("init_prompt")
@@ -265,18 +273,19 @@ class OpenaiApiASR(ASRBase):
         sf.write(buffer, audio_data, samplerate=16000, format="WAV", subtype="PCM_16")
         buffer.seek(0)
         self.transcribed_seconds += math.ceil(len(audio_data) / 16000)
+        task = self.transcribe_kargs.get("task", self.task)
         params = {
             "model": self.modelname,
             "file": buffer,
             "response_format": self.response_format,
             "temperature": self.temperature,
-            "timestamp_granularities": ["word", "segment"],
         }
-        if not self.direct_english_translation and self.original_language:
-            params["language"] = self.original_language
+        if task != "translate":
+            params["timestamp_granularities"] = ["word", "segment"]
+            if not self.direct_english_translation and self.original_language:
+                params["language"] = self.original_language
         if prompt:
             params["prompt"] = prompt
-        task = self.transcribe_kargs.get("task", self.task)
         proc = self.client.audio.translations if task == "translate" else self.client.audio.transcriptions
         transcript = proc.create(**params)
         logger.debug(f"OpenAI API processed accumulated {self.transcribed_seconds} seconds")


### PR DESCRIPTION
## Summary

`OpenaiApiASR.transcribe()` built a single `params` dict and routed it to either `client.audio.transcriptions.create(**params)` or `client.audio.translations.create(**params)` depending on `task`. The dict always included `timestamp_granularities`, and included `language` whenever `original_language` was set — but the OpenAI translations endpoint accepts neither parameter, so any translate call (`--backend openai-api --direct-english-translation`) raised a client-side `TypeError` for the unexpected keyword argument instead of returning a translation.

The existing guard, `if not self.direct_english_translation and self.original_language`, was meant to drop `language` for translate calls, but `self.direct_english_translation` is never set on the `OpenaiApiASR` instance — `backend_factory` in `whisper_online.py` only sets `asr.transcribe_kargs["task"] = "translate"`. So the guard never actually fired on the real translate path.

Separately, once the extra params are removed, a real translate response still crashed: `ts_words()` and `segments_end_ts()` unconditionally read `segments.words` / `res.words`. The OpenAI translations endpoint's verbose-json response (`TranslationVerbose`) has no `words` field, only `segments` — so both methods raised `AttributeError` on any translate call.

## Fix

- In `transcribe()`, resolve `task` before building `params`, and only add `timestamp_granularities` (and `language`, subject to the existing guard) when `task != "translate"`.
- In `ts_words()` and `segments_end_ts()`, fall back to segment-level data (`segment.start`/`segment.end`/`segment.text`) when the response has no `words` attribute, instead of assuming word-level timestamps are always present.

## User impact

Fixes `--backend openai-api --direct-english-translation` (and any other path that sets `task=translate` for the OpenAI API backend), which previously failed on every call. Transcription-only calls (`task != "translate"`) are unaffected — `params` still gets `timestamp_granularities` and `language` exactly as before. No config or CLI surface changes.

## Validation

```
uv run pytest -q tests/test_backend_deep_bugs.py -k "openai_api_asr"
-> 2 passed, 53 deselected in 1.42s

uv run pytest -q tests/test_backend_deep_bugs.py
-> 55 passed in 1.95s

uv run pytest -q tests/ --ignore=tests/test_pipeline.py
-> 306 passed, 15 skipped, 6 warnings in 137.60s

uv run ruff check whisperlivekit/local_agreement/backends.py tests/test_backend_deep_bugs.py
-> All checks passed!

uv lock --check
-> Resolved 405 packages (no drift)
```

Pre-fix regression check (source reverted via `git stash`, tests kept): the same `-k openai_api_asr` run produced 2 failures — an `AssertionError` (`timestamp_granularities` present in the translate call's params) and an `AttributeError` (`'types.SimpleNamespace' object has no attribute 'words'`) — confirming RED before the fix and GREEN after.

`test_openai_api_asr_initializes_transcribe_kwargs_and_routes_tasks` now asserts `timestamp_granularities`/`language` are absent from the translate call's params (previously the fake endpoint swallowed any kwargs without asserting on them). Added `test_openai_api_asr_ts_words_and_segments_end_ts_handle_translation_responses`, which feeds a segments-only (no `words`) response through `ts_words()`/`segments_end_ts()` to prove no `AttributeError`.

Not run: `tests/test_pipeline.py` (the real-model pipeline suite) — it downloads Whisper model weights and needs real hardware/backends per `CONTRIBUTING.md`, which is disproportionate for a params/response-parsing fix scoped to one backend class. Also not run: any live OpenAI API call — no API key was used and no network spend was made; the response shape (`TranslationVerbose` has no `words` field) and the `Translations.create()` signature were confirmed from the `openai` SDK's installed type stubs in a local venv.

## Checklist

- [x] I searched for an existing issue or discussion and linked it when relevant. (No existing issue found for this bug.)
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-facing changes. (No user-facing docs reference these params; none needed.)
- [x] I ran `ruff check .`.
- [x] I ran the relevant pytest suite.
- [x] I did not commit credentials, model weights, generated caches, or private data.
