### PR TITLE
fix: bound streaming queues and reap FFmpeg on disconnect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,11 @@ jobs:
       - name: Install package with test deps
         run: pip install -e ".[test]" qwen3-asr-causal
 
+      - name: Install FFmpeg for audio integration tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+
       - name: Run regression suite
         run: pytest -q tests/ --ignore=tests/test_pipeline.py --ignore=tests/test_asr_coalescing_pipeline.py
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,8 @@ same settings as the CLI.
 | `--diarization` | Attribute words to speakers | disabled |
 | `--pause-segmentation-seconds` | Split after a VAD pause longer than this threshold; `0` disables it | `5.0` |
 | `--asr-coalesce-min-s` | Accumulate new audio before inference; trades update cadence for fewer calls | `0` |
+| `--max-buffered-audio` | Maximum queued audio, in seconds, per ASR/diarization stage | `30` |
+| `--backpressure-timeout` | Maximum wait for room in a processing queue, in seconds | `30` |
 | `--pcm-input` | Accept mono 16 kHz signed 16-bit little-endian PCM and bypass FFmpeg | disabled |
 | `--api-token` | Require authentication; falls back to `WLK_API_TOKEN` | unset |
 | `--cors-origins` | Comma-separated browser origins allowed to call the API | none |
@@ -55,9 +57,23 @@ including feeding and final drainage, is `max(120 seconds, 2.5 × audio duration
 `--rest-timeout N` sets each phase's budget to N seconds. Timeout returns HTTP 408;
 cancellation and errors close the processor's tasks and conversion process.
 
-These limits do not establish a server-wide concurrency capacity. Full-history
-sessions and pending audio still consume memory; measure your workload and
-limit concurrent sessions at deployment. See [deployment.md](deployment.md).
+Pending audio is bounded independently in the ASR and diarization queues.
+When a queue is full, audio ingestion waits for room instead of dropping
+samples. Processing queues also hold at most 256 items, including silence and
+speaker boundaries; the translation queue uses this item limit. A queue that
+cannot accept work within `--backpressure-timeout` ends the session with an
+explicit error (HTTP 503 for REST; an error message followed by close code 1011
+for WebSocket). Increase the timeout for slow models or long inference calls.
+Both settings must be finite and positive.
+
+`SESSION_METRICS` logs include `peak_queued_audio_s` (the largest audio queue)
+and `backpressure_wait_s` (cumulative producer wait across processing queues).
+They exclude the batch currently being processed and are not word latency.
+
+These bounds do not cap all process memory: model buffers, an incoming network
+message, REST uploads, translation-backend history and full transcript history
+have their own lifetimes. Measure the workload and limit concurrent sessions
+at deployment. See [deployment.md](deployment.md).
 
 ## Embedding the server
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -895,6 +895,7 @@ async def test_ffmpeg_reader_drains_stdout_after_stop_before_sentinel():
     processor = object.__new__(AudioProcessor)
     processor.is_stopping = True
     processor.ffmpeg_manager = FakeFFmpegManager([b"aaaa", None, b"bbbb", b""])
+    processor.max_bytes_per_sec = 160000
     processor.pcm_buffer = bytearray()
     processor.transcription_queue = asyncio.Queue()
     processor.diarization_queue = None

--- a/tests/test_pause_segmentation.py
+++ b/tests/test_pause_segmentation.py
@@ -48,6 +48,7 @@ def _silence_processor(threshold: float) -> AudioProcessor:
     processor = object.__new__(AudioProcessor)
     processor.pause_segmentation_seconds = threshold
     processor.sample_rate = 100
+    processor.max_bytes_per_sec = 1000
     processor.total_pcm_samples = 0
     processor.current_silence = Silence(start=1.0, is_starting=True)
     processor.metrics = SessionMetrics()

--- a/tests/test_streaming_lifecycle.py
+++ b/tests/test_streaming_lifecycle.py
@@ -211,8 +211,32 @@ async def test_full_pipeline_timeout_and_cleanup_release_blocked_feeds(engine):
             await asyncio.gather(producer, return_exceptions=True)
             await processor.cleanup()
 
+    if shutil.which("ffmpeg"):
+        # Encoded input can block on FFmpeg stdin while decoded output waits
+        # on a full queue. Overload must release that writer as well.
+        processor = AudioProcessor(transcription_engine=engine, pcm_input=False)
+        processor.transcription_queue.timeout = .05
+        assert await processor.ffmpeg_manager.start()
+        process = processor.ffmpeg_manager.process
+        reader = asyncio.create_task(processor.ffmpeg_stdout_reader())
+        processor.all_tasks_for_cleanup.append(reader)
+        producer = asyncio.create_task(processor.process_audio(_wav(bytes(32000 * 30))))
+        try:
+            async with asyncio.timeout(5):
+                await producer
+                await reader
+            assert processor.overload_error and "backlog" in processor.overload_error
+            assert process.returncode is not None
+            assert processor.ffmpeg_manager.process is None
+        finally:
+            producer.cancel()
+            await asyncio.gather(producer, return_exceptions=True)
+            await processor.cleanup()
+
 
 def test_overload_reaches_http_and_websocket_clients(engine, monkeypatch):
+    if not shutil.which("ffmpeg"):
+        pytest.skip("ffmpeg required for REST audio conversion")
     from fastapi.testclient import TestClient
     from starlette.websockets import WebSocketDisconnect
 

--- a/tests/test_streaming_lifecycle.py
+++ b/tests/test_streaming_lifecycle.py
@@ -1,0 +1,251 @@
+"""Real subprocess teardown and bounded, lossless ingestion under load."""
+
+import asyncio
+import io
+import shutil
+import sys
+import wave
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from whisperlivekit.audio_processor import SENTINEL, AudioProcessor, get_all_from_queue
+from whisperlivekit.core import TranscriptionEngine
+from whisperlivekit.ffmpeg_manager import FFmpegManager, FFmpegState
+from whisperlivekit.processing_queue import PipelineClosed, PipelineOverloaded, ProcessingQueue
+
+
+def _wav(pcm):
+    out = io.BytesIO()
+    with wave.open(out, "wb") as audio:
+        audio.setnchannels(1)
+        audio.setsampwidth(2)
+        audio.setframerate(16000)
+        audio.writeframes(pcm)
+    return out.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_ffmpeg_drains_eof_and_reaps_abandoned_or_cancelled_sessions(monkeypatch):
+    if not shutil.which("ffmpeg"):
+        pytest.skip("ffmpeg required for real process lifecycle coverage")
+    manager = FFmpegManager()
+    monkeypatch.setattr(manager, "_STOP_TIMEOUT", .2)
+    monkeypatch.setattr(manager, "_TERMINATE_TIMEOUT", .2)
+    writer = None
+    process = None
+    try:
+        # Normal EOF must retain every sample, and the manager must restart.
+        assert await manager.start()
+        process = manager.process
+        pcm = np.arange(16000, dtype=np.int16).tobytes()
+        assert await manager.write_data(_wav(pcm))
+        await manager.close_stdin()
+        decoded = bytearray()
+        async with asyncio.timeout(5):
+            while chunk := await manager.read_data(4096):
+                decoded.extend(chunk)
+            await manager.stop()
+        assert decoded == pcm
+        assert process.returncode == 0
+
+        # A client disconnects while the decoder's output pipe is full.
+        assert await manager.restart()
+        process = manager.process
+        writer = asyncio.create_task(manager.write_data(_wav(pcm * 30)))
+        assert await asyncio.wait_for(manager.read_data(1), 5)
+        await asyncio.sleep(.05)
+        await asyncio.wait_for(manager.stop(), 5)
+        await writer
+        assert process.returncode is not None
+        assert manager.process is None
+
+        # Cancellation and a second stop must still reap a child ignoring TERM.
+        spawn = asyncio.create_subprocess_exec
+
+        async def stubborn_child(*args, **kwargs):
+            return await spawn(
+                sys.executable, "-c",
+                "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "print('ready', flush=True); time.sleep(30)",
+                **kwargs,
+            )
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", stubborn_child)
+        assert await manager.start()
+        process = manager.process
+        assert await asyncio.wait_for(manager.read_data(6), 5) == b"ready\n"
+        stop = asyncio.create_task(manager.stop())
+        await asyncio.sleep(0)
+        stop.cancel()
+        async with asyncio.timeout(5):
+            await manager.stop()
+            with pytest.raises(asyncio.CancelledError):
+                await stop
+        assert process.returncode is not None
+        assert manager.process is None
+        assert await manager.get_state() == FFmpegState.STOPPED
+    finally:
+        if process is not None and process.returncode is None:
+            process.kill()
+            await process.communicate()
+        if writer is not None:
+            await asyncio.gather(writer, return_exceptions=True)
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    # Exercise real ingestion and queues without loading an inference model.
+    monkeypatch.setattr(TranscriptionEngine, "_instance", None)
+    monkeypatch.setattr(TranscriptionEngine, "_initialized", False)
+    shared = TranscriptionEngine(
+        transcription=False, vac=False, pcm_input=True,
+        max_buffered_audio=.2, backpressure_timeout=2,
+    )
+    shared.args.transcription = True
+    monkeypatch.setattr(
+        "whisperlivekit.audio_processor.online_factory",
+        lambda *args, **kwargs: SimpleNamespace(asr=SimpleNamespace(sep=" ")),
+    )
+    return shared
+
+
+@pytest.mark.asyncio
+async def test_bounded_ingestion_preserves_samples_and_isolates_slow_sessions(engine):
+    slow = AudioProcessor(transcription_engine=engine)
+    fast = AudioProcessor(transcription_engine=engine)
+    released = asyncio.Event()
+    seen = {slow: [], fast: []}
+
+    async def consume(processor, gate=None):
+        if gate:
+            await gate.wait()
+        while True:
+            item = await get_all_from_queue(processor.transcription_queue)
+            if item is SENTINEL:
+                return
+            if isinstance(item, np.ndarray):
+                seen[processor].append(item)
+            await asyncio.sleep(0)
+
+    pcm = np.arange(24001, dtype=np.int16).tobytes()
+
+    async def feed(processor):
+        # The first sample straddles messages; the second message exceeds the
+        # queue's capacity, so the producer must split and wait without loss.
+        await processor.process_audio(pcm[:1])
+        await processor.process_audio(pcm[1:])
+        await processor.process_audio(b"")
+
+    consumers = [asyncio.create_task(consume(slow, released)), asyncio.create_task(consume(fast))]
+    producers = [asyncio.create_task(feed(slow)), asyncio.create_task(feed(fast))]
+    try:
+        await asyncio.wait_for(producers[1], 2)
+        await asyncio.wait_for(consumers[1], 2)
+        assert not producers[0].done()
+        assert slow.transcription_queue.queued_samples <= 3200
+        assert len(slow.pcm_buffer) <= slow.max_bytes_per_sec
+        released.set()
+        async with asyncio.timeout(2):
+            await producers[0]
+            await consumers[0]
+        expected = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768
+        for processor in (slow, fast):
+            np.testing.assert_array_equal(np.concatenate(seen[processor]), expected)
+            assert processor.total_pcm_samples == len(expected)
+            assert processor.transcription_queue.peak_samples <= 3200
+            assert not processor.pcm_buffer
+    finally:
+        for task in producers + consumers:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*producers, *consumers, return_exceptions=True)
+        await slow.cleanup()
+        await fast.cleanup()
+    assert slow.metrics.backpressure_wait_s > 0
+    assert slow.metrics.peak_queued_audio_s <= .2
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_timeout_and_cleanup_release_blocked_feeds(engine):
+    queue = ProcessingQueue("Audio", max_samples=8)
+    await queue.put(np.ones(4))
+    await queue.put(np.ones(4))
+    large = asyncio.create_task(queue.put(np.ones(8)))
+    small = asyncio.create_task(queue.put(np.ones(2)))
+    try:
+        await asyncio.sleep(0)
+        await queue.get()
+        queue.task_done()
+        await asyncio.wait_for(small, 1)
+        assert not large.done()
+    finally:
+        large.cancel()
+        small.cancel()
+        await asyncio.gather(large, small, return_exceptions=True)
+        queue.close()
+    await asyncio.wait_for(queue.join(), 1)
+
+    for timeout in (True, False):
+        processor = AudioProcessor(transcription_engine=engine)
+        processor.transcription_queue.timeout = .05 if timeout else 30
+        producer = asyncio.create_task(processor.process_audio(bytes(32000)))
+        try:
+            if timeout:
+                with pytest.raises(PipelineOverloaded, match="backlog"):
+                    await asyncio.wait_for(producer, 2)
+                response = await anext(processor.results_formatter())
+                assert response.status == "error" and "backlog" in response.error
+            else:
+                await asyncio.sleep(.01)
+                assert not producer.done()
+                await processor.cleanup()
+                with pytest.raises(PipelineClosed):
+                    await asyncio.wait_for(producer, 2)
+            assert processor.transcription_queue.closed
+            assert processor.transcription_queue.queued_samples == 0
+        finally:
+            if not producer.done():
+                producer.cancel()
+            await asyncio.gather(producer, return_exceptions=True)
+            await processor.cleanup()
+
+
+def test_overload_reaches_http_and_websocket_clients(engine, monkeypatch):
+    from fastapi.testclient import TestClient
+    from starlette.websockets import WebSocketDisconnect
+
+    from whisperlivekit.basic_server import create_app
+
+    engine.args.backpressure_timeout = .05
+    processors = []
+
+    async def stalled_inference(processor):
+        processors.append(processor)
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(AudioProcessor, "transcription_processor", stalled_inference)
+    with TestClient(create_app(engine.config)) as client:
+        response = client.post(
+            "/v1/audio/transcriptions", files={"file": ("audio.wav", _wav(bytes(32000)), "audio/wav")},
+        )
+        assert response.status_code == 503, response.text
+        assert "backlog" in response.json()["detail"]
+        for endpoint, greeting, error_field in (
+            ("/asr", "config", "error"),
+            ("/v1/listen?encoding=linear16&sample_rate=16000&endpointing=false", "Metadata", "description"),
+        ):
+            with client.websocket_connect(endpoint) as ws:
+                assert ws.receive_json()["type"] == greeting
+                ws.send_bytes(bytes(32000))
+                while True:
+                    message = ws.receive_json()
+                    if message.get(error_field):
+                        assert "backlog" in message[error_field]
+                        break
+                with pytest.raises(WebSocketDisconnect) as closed:
+                    ws.receive_json()
+                assert closed.value.code == 1011
+    assert len(processors) == 3
+    assert all(task.done() for processor in processors for task in processor.all_tasks_for_cleanup)

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -17,6 +17,7 @@ from whisperlivekit.core import (
 )
 from whisperlivekit.ffmpeg_manager import FFmpegManager, FFmpegState
 from whisperlivekit.metrics_collector import SessionMetrics
+from whisperlivekit.processing_queue import PipelineClosed, PipelineOverloaded, ProcessingQueue
 from whisperlivekit.silero_vad_iterator import FixedVADIterator, OnnxWrapper, load_jit_vad
 from whisperlivekit.timed_objects import (
     ASRToken,
@@ -132,7 +133,8 @@ class AudioProcessor:
         self.samples_per_sec = int(self.sample_rate * chunk_seconds)
         self.bytes_per_sample = 2
         self.bytes_per_sec = self.samples_per_sec * self.bytes_per_sample
-        self.max_bytes_per_sec = 32000 * 5  # 5 seconds of audio at 32 kHz
+        max_samples = max(1, int(getattr(self.args, "max_buffered_audio", 30.0) * self.sample_rate))
+        self.max_bytes_per_sec = min(32000 * 5, max_samples * self.bytes_per_sample)
         self.is_pcm_input = (
             self.args.pcm_input
             if session_pcm_input is None
@@ -181,9 +183,22 @@ class AudioProcessor:
                 self._ffmpeg_error = error_type
             self.ffmpeg_manager.on_error_callback = handle_ffmpeg_error
 
-        self.transcription_queue: Optional[asyncio.Queue] = asyncio.Queue() if self.args.transcription else None
-        self.diarization_queue: Optional[asyncio.Queue] = asyncio.Queue() if self.args.diarization else None
-        self.translation_queue: Optional[asyncio.Queue] = asyncio.Queue() if self.args.target_language else None
+        self.overload_error: Optional[str] = None
+        queue_options = {
+            "timeout": getattr(self.args, "backpressure_timeout", 30.0),
+            "on_overload": self._on_overload,
+        }
+        self.transcription_queue = (
+            ProcessingQueue("Transcription", max_samples=max_samples, **queue_options)
+            if self.args.transcription else None
+        )
+        self.diarization_queue = (
+            ProcessingQueue("Diarization", max_samples=max_samples, **queue_options)
+            if self.args.diarization else None
+        )
+        self.translation_queue = (
+            ProcessingQueue("Translation", **queue_options) if self.args.target_language else None
+        )
         self.pcm_buffer: bytearray = bytearray()
         self.total_pcm_samples: int = 0
         self.transcription_task: Optional[asyncio.Task] = None
@@ -234,6 +249,17 @@ class AudioProcessor:
         # Silent-backend watchdog: flips once the ASR has produced anything.
         self._any_asr_output: bool = False
         self._silent_backend_warned: bool = False
+
+    def _on_overload(self, message):
+        self.overload_error = message
+        self.is_stopping = True
+        logger.warning("Closing overloaded audio session: %s", message)
+        self._close_queues()
+
+    def _close_queues(self):
+        for queue in (self.transcription_queue, self.diarization_queue, self.translation_queue):
+            if isinstance(queue, ProcessingQueue):
+                queue.close()
 
     async def _emit_stream_event(self, kind: str, timestamp: float) -> None:
         """Publish a protocol-neutral event on the submitted audio clock."""
@@ -503,7 +529,7 @@ class AudioProcessor:
 
                 current_time = time()
                 elapsed_time = max(0.0, current_time - beg)
-                buffer_size = max(int(32000 * elapsed_time), 4096)  # dynamic read
+                buffer_size = min(max(int(32000 * elapsed_time), 4096), self.max_bytes_per_sec)
                 beg = current_time
 
                 chunk = await self.ffmpeg_manager.read_data(buffer_size)
@@ -521,6 +547,8 @@ class AudioProcessor:
                 logger.info("ffmpeg_stdout_reader cancelled.")
                 cancelled = True
                 break
+            except (PipelineClosed, PipelineOverloaded):
+                return
             except Exception as e:
                 logger.warning(f"Exception in ffmpeg_stdout_reader: {e}")
                 logger.debug(f"Traceback: {traceback.format_exc()}")
@@ -819,11 +847,11 @@ class AudioProcessor:
                     if item.is_starting:
                         await self._flush_pending_translation_tokens()
                     await self.translation_queue.put(item)
+            except (PipelineClosed, PipelineOverloaded):
+                return
             except Exception as e:
                 logger.warning(f"Exception in transcription_processor: {e}")
                 logger.warning(f"Traceback: {traceback.format_exc()}")
-                if 'pcm_array' in locals() and pcm_array is not SENTINEL : # Check if pcm_array was assigned from queue
-                    self.transcription_queue.task_done()
 
         if self.is_stopping:
             logger.info("Transcription processor finishing due to stopping flag.")
@@ -881,6 +909,8 @@ class AudioProcessor:
                     async with self.lock:
                         self.state.new_diarization = diarization_segments
                         self.state.end_attributed_speaker = max(self.state.end_attributed_speaker, diar_end)
+            except (PipelineClosed, PipelineOverloaded):
+                return
             except Exception as e:
                 logger.warning(f"Exception in diarization_processor: {e}")
                 logger.warning(f"Traceback: {traceback.format_exc()}")
@@ -927,6 +957,8 @@ class AudioProcessor:
                             self.state.new_translation_buffer = new_translation_buffer
                 if item is SENTINEL:
                     break
+            except (PipelineClosed, PipelineOverloaded):
+                return
             except Exception as e:
                 logger.warning(f"Exception in translation_processor: {e}")
                 logger.warning(f"Traceback: {traceback.format_exc()}")
@@ -938,6 +970,9 @@ class AudioProcessor:
         """Format processing results for output."""
         while True:
             try:
+                if getattr(self, "overload_error", None):
+                    yield FrontData(status="error", error=self.overload_error)
+                    return
                 if self._ffmpeg_error:
                     yield FrontData(status="error", error=f"FFmpeg error: {self._ffmpeg_error}")
                     return
@@ -1077,6 +1112,7 @@ class AudioProcessor:
         """Clean up resources when processing is complete."""
         logger.info("Starting cleanup of AudioProcessor resources.")
         self.is_stopping = True
+        self._close_queues()
         close_translation = getattr(self.translation, "close", None)
         if close_translation is not None:
             try:
@@ -1102,6 +1138,10 @@ class AudioProcessor:
             self.diarization.close()
 
         # Finalize session metrics
+        queues = [q for q in (self.transcription_queue, self.diarization_queue, self.translation_queue)
+                  if isinstance(q, ProcessingQueue)]
+        self.metrics.backpressure_wait_s = sum(q.wait_seconds for q in queues)
+        self.metrics.peak_queued_audio_s = max((q.peak_samples for q in queues), default=0) / self.sample_rate
         self.metrics.total_audio_duration_s = self.total_pcm_samples / self.sample_rate
         self.metrics.log_summary()
         logger.info("AudioProcessor cleanup complete.")
@@ -1146,8 +1186,12 @@ class AudioProcessor:
         self.metrics.n_chunks_received += 1
 
         if self.is_pcm_input:
-            self.pcm_buffer.extend(message)
-            await self.handle_pcm_data()
+            # Keep the pipeline buffer bounded even when a file client submits
+            # a large message. Waiting on a full queue slows the sender in place.
+            view = memoryview(message)
+            for offset in range(0, len(view), self.max_bytes_per_sec):
+                self.pcm_buffer.extend(view[offset:offset + self.max_bytes_per_sec])
+                await self.handle_pcm_data()
         else:
             if not self.ffmpeg_manager:
                 logger.error("FFmpeg manager not initialized for non-PCM input.")
@@ -1166,28 +1210,18 @@ class AudioProcessor:
         if not self.args.vac and self.current_silence:
             await self._end_silence(speech_resumed=True)
 
-        # Process when enough data
-        if len(self.pcm_buffer) < self.bytes_per_sec:
-            return
+        threshold = min(self.bytes_per_sec, self.max_bytes_per_sec)
+        while len(self.pcm_buffer) >= threshold:
+            chunk_size = min(len(self.pcm_buffer), self.max_bytes_per_sec)
+            aligned_chunk_size = (chunk_size // self.bytes_per_sample) * self.bytes_per_sample
+            if aligned_chunk_size == 0:
+                return
+            pcm_array = self.convert_pcm_to_float(self.pcm_buffer[:aligned_chunk_size])
+            del self.pcm_buffer[:aligned_chunk_size]
+            await self._process_pcm_array(pcm_array)
 
-        if len(self.pcm_buffer) > self.max_bytes_per_sec:
-            logger.warning(
-                f"Audio buffer too large: {len(self.pcm_buffer) / self.bytes_per_sec:.2f}s. "
-                f"Consider using a smaller model."
-            )
-
-        chunk_size = min(len(self.pcm_buffer), self.max_bytes_per_sec)
-        aligned_chunk_size = (chunk_size // self.bytes_per_sample) * self.bytes_per_sample
-
-        if aligned_chunk_size == 0:
-            return
-        pcm_array = self.convert_pcm_to_float(self.pcm_buffer[:aligned_chunk_size])
-        self.pcm_buffer = self.pcm_buffer[aligned_chunk_size:]
-
-        await self._process_pcm_array(pcm_array)
-
-        if not self.args.transcription and not self.args.diarization:
-            await asyncio.sleep(0.1)
+            if not self.args.transcription and not self.args.diarization:
+                await asyncio.sleep(0.1)
 
     async def _process_pcm_array(self, pcm_array: np.ndarray) -> None:
         """Apply VAC segmentation to one PCM array and advance stream time."""
@@ -1267,9 +1301,10 @@ class AudioProcessor:
         if aligned_size == 0:
             await self._finalize_current_silence_at_stream_end()
             return
-        pcm_array = self.convert_pcm_to_float(self.pcm_buffer[:aligned_size])
-        self.pcm_buffer = self.pcm_buffer[aligned_size:]
-
-        await self._process_pcm_array(pcm_array)
+        while aligned_size:
+            size = min(aligned_size, self.max_bytes_per_sec)
+            pcm_array = self.convert_pcm_to_float(self.pcm_buffer[:size])
+            del self.pcm_buffer[:size]
+            await self._process_pcm_array(pcm_array)
+            aligned_size -= size
         await self._finalize_current_silence_at_stream_end()
-        logger.info(f"Flushed remaining PCM buffer: {len(pcm_array)} samples ({len(pcm_array)/self.sample_rate:.2f}s)")

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -548,6 +548,9 @@ class AudioProcessor:
                 cancelled = True
                 break
             except (PipelineClosed, PipelineOverloaded):
+                # Encoded input may still be blocked in stdin.drain(). Reap
+                # the decoder now so that producer can reach session cleanup.
+                await self.ffmpeg_manager.stop()
                 return
             except Exception as e:
                 logger.warning(f"Exception in ffmpeg_stdout_reader: {e}")

--- a/whisperlivekit/basic_server.py
+++ b/whisperlivekit/basic_server.py
@@ -12,6 +12,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 from whisperlivekit import AudioProcessor, TranscriptionEngine, get_inline_ui_html, parse_args
 from whisperlivekit.api_auth import websocket_token
 from whisperlivekit.config import WhisperLiveKitConfig, parse_cors_origins
+from whisperlivekit.processing_queue import PipelineClosed, PipelineOverloaded
 from whisperlivekit.timed_objects import FrontData
 from whisperlivekit.timed_objects import format_subtitle_timestamp as _srt_timestamp
 
@@ -169,7 +170,10 @@ async def websocket_endpoint(websocket: WebSocket):
     except Exception as e:
         logger.error(f"Unexpected error in websocket_endpoint main loop: {e}", exc_info=True)
         try:
-            await websocket.send_json({"type": "error", "error": "Unable to process audio."})
+            await websocket.send_json({
+                "type": "error",
+                "error": getattr(audio_processor, "overload_error", None) or "Unable to process audio.",
+            })
             await websocket.close(code=1011, reason="transcription failed")
         except Exception:
             logger.debug("WebSocket was already disconnected", exc_info=True)
@@ -538,7 +542,10 @@ async def create_transcription(
         nonlocal final_result
         async for result in results_gen:
             if result.status == "error":
-                raise HTTPException(status_code=500, detail=result.error or "Transcription failed")
+                raise HTTPException(
+                    status_code=503 if getattr(processor, "overload_error", None) else 500,
+                    detail=result.error or "Transcription failed",
+                )
             final_result = result
 
     # The feed/drain budget scales with the audio length
@@ -561,6 +568,9 @@ async def create_transcription(
                     await collect_task  # propagate errors while feeding
             await processor.process_audio(b"")
             await collect_task
+    except (PipelineClosed, PipelineOverloaded) as exc:
+        message = getattr(processor, "overload_error", None)
+        raise HTTPException(status_code=503 if message else 500, detail=message or str(exc)) from exc
     except asyncio.TimeoutError:
         timed_out = True
         logger.warning(

--- a/whisperlivekit/config.py
+++ b/whisperlivekit/config.py
@@ -83,6 +83,8 @@ class WhisperLiveKitConfig:
     retention_seconds: Optional[float] = None
     # REST /v1/audio/transcriptions budget; 0 = auto (max(120, 2.5x audio)).
     rest_timeout: float = 0.0
+    max_buffered_audio: float = 30.0
+    backpressure_timeout: float = 30.0
     model_size: str = "base"
     model_cache_dir: Optional[str] = None
     model_dir: Optional[str] = None
@@ -182,6 +184,11 @@ class WhisperLiveKitConfig:
     sortformer_max_speakers: Optional[int] = None
 
     def __post_init__(self):
+        for name in ("max_buffered_audio", "backpressure_timeout"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be finite and positive.")
+            setattr(self, name, value)
         if self.punctuation_split or self.disable_punctuation_split:
             logger.warning(
                 "--punctuation-split and --disable-punctuation-split are deprecated "

--- a/whisperlivekit/deepgram_compat.py
+++ b/whisperlivekit/deepgram_compat.py
@@ -1121,7 +1121,9 @@ async def handle_deepgram_websocket(
         logger.exception("Deepgram-compatible WebSocket failed")
         if not server_closed and not client_disconnected:
             with suppress(Exception):
-                await adapter.send_error("Internal transcription error.")
+                await adapter.send_error(
+                    getattr(audio_processor, "overload_error", None) or "Internal transcription error."
+                )
             with suppress(Exception):
                 await websocket.close(code=1011, reason="internal error")
             server_closed = True

--- a/whisperlivekit/ffmpeg_manager.py
+++ b/whisperlivekit/ffmpeg_manager.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import logging
 from enum import Enum
 from typing import Callable, Optional
@@ -32,16 +31,23 @@ class FFmpegState(Enum):
     STOPPED = "stopped"
     STARTING = "starting"
     RUNNING = "running"
+    STOPPING = "stopping"
     RESTARTING = "restarting"
     FAILED = "failed"
 
 class FFmpegManager:
+    _STOP_TIMEOUT = 2.0
+    _TERMINATE_TIMEOUT = 1.0
+
     def __init__(self, sample_rate: int = 16000, channels: int = 1):
         self.sample_rate = sample_rate
         self.channels = channels
 
         self.process: Optional[asyncio.subprocess.Process] = None
         self._stderr_task: Optional[asyncio.Task] = None
+        self._stop_task: Optional[asyncio.Task] = None
+        self._read_lock = asyncio.Lock()
+        self._restart_lock = asyncio.Lock()
 
         self.on_error_callback: Optional[Callable[[str], None]] = None
 
@@ -49,40 +55,29 @@ class FFmpegManager:
         self._state_lock = asyncio.Lock()
 
     async def start(self) -> bool:
-        async with self._state_lock:
-            if self.state != FFmpegState.STOPPED:
-                logger.warning(f"FFmpeg already running in state: {self.state}")
-                return False
-            self.state = FFmpegState.STARTING
-
         try:
-            cmd = [
-                "ffmpeg",
-                "-hide_banner",
-                "-loglevel", "error",
-                "-i", "pipe:0",
-                "-f", "s16le",
-                "-acodec", "pcm_s16le",
-                "-ac", str(self.channels),
-                "-ar", str(self.sample_rate),
-                "pipe:1"
-            ]
-
-            self.process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
-
-            self._stderr_task = asyncio.create_task(self._drain_stderr())
-
             async with self._state_lock:
+                if self.state != FFmpegState.STOPPED:
+                    logger.warning("FFmpeg already running in state: %s", self.state)
+                    return False
+                self.state = FFmpegState.STARTING
+                self._stop_task = None
+                self.process = await asyncio.create_subprocess_exec(
+                    "ffmpeg", "-hide_banner", "-loglevel", "error",
+                    "-i", "pipe:0", "-f", "s16le", "-acodec", "pcm_s16le",
+                    "-ac", str(self.channels), "-ar", str(self.sample_rate), "pipe:1",
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                self._stderr_task = asyncio.create_task(self._drain_stderr())
                 self.state = FFmpegState.RUNNING
-
             logger.info("FFmpeg started.")
             return True
 
+        except asyncio.CancelledError:
+            await self.stop()
+            raise
         except FileNotFoundError:
             logger.error(ERROR_INSTALL_INSTRUCTIONS)
             async with self._state_lock:
@@ -100,22 +95,66 @@ class FFmpegManager:
             return False
 
     async def stop(self):
+        """Reap the process, discarding unread output on an aborted session.
+
+        Normal EOF uses close_stdin() and lets the pipeline consume stdout
+        before calling stop(). A disconnected client may leave both pipes full.
+        """
         async with self._state_lock:
-            if self.state == FFmpegState.STOPPED:
+            if self._stop_task is None:
+                self.state = FFmpegState.STOPPING
+                self._stop_task = asyncio.create_task(self._stop_process())
+            task = self._stop_task
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # Request cancellation must not abandon the child process.
+            await asyncio.shield(task)
+            raise
+
+    async def _stop_process(self):
+        process = self.process
+        drain_task = None
+        try:
+            if process is None:
                 return
-            self.state = FFmpegState.STOPPED
-
-        if self.process:
-            await self.close_stdin()
-            await self.process.wait()
+            if process.stdin:
+                process.stdin.close()
+            drain_task = asyncio.create_task(self._discard_stdout(process))
+            if self._stderr_task is None:
+                self._stderr_task = asyncio.create_task(self._drain_stderr())
+            try:
+                await asyncio.wait_for(process.wait(), self._STOP_TIMEOUT)
+            except asyncio.TimeoutError:
+                if process.returncode is None:
+                    try:
+                        process.terminate()
+                    except ProcessLookupError:
+                        pass
+                try:
+                    await asyncio.wait_for(process.wait(), self._TERMINATE_TIMEOUT)
+                except asyncio.TimeoutError:
+                    if process.returncode is None:
+                        try:
+                            process.kill()
+                        except ProcessLookupError:
+                            pass
+                    await process.wait()
+        finally:
+            drains = [task for task in (drain_task, self._stderr_task) if task]
+            if drains:
+                await asyncio.gather(*drains, return_exceptions=True)
+            self._stderr_task = None
             self.process = None
+            async with self._state_lock:
+                self.state = FFmpegState.STOPPED
+            logger.info("FFmpeg stopped.")
 
-        if self._stderr_task:
-            self._stderr_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._stderr_task
-
-        logger.info("FFmpeg stopped.")
+    async def _discard_stdout(self, process):
+        async with self._read_lock:
+            if process.stdout:
+                while await process.stdout.read(65536):
+                    pass
 
     async def close_stdin(self):
         """Close FFmpeg stdin while keeping stdout readable for draining."""
@@ -146,10 +185,11 @@ class FFmpegManager:
                 return None
 
         try:
-            data = await asyncio.wait_for(
-                self.process.stdout.read(size),
-                timeout=20.0
-            )
+            async with self._read_lock:
+                process = self.process
+                if process is None:
+                    return b""
+                data = await asyncio.wait_for(process.stdout.read(size), timeout=20.0)
             return data
         except asyncio.TimeoutError:
             logger.warning("FFmpeg read timeout.")
@@ -165,32 +205,28 @@ class FFmpegManager:
             return self.state
 
     async def restart(self) -> bool:
-        async with self._state_lock:
-            if self.state == FFmpegState.RESTARTING:
-                logger.warning("Restart already in progress.")
-                return False
-            self.state = FFmpegState.RESTARTING
-
-        logger.info("Restarting FFmpeg...")
-
-        try:
-            await self.stop()
-            await asyncio.sleep(1)  # short delay before restarting
-            return await self.start()
-        except Exception as e:
-            logger.error(f"Error during FFmpeg restart: {e}")
-            async with self._state_lock:
-                self.state = FFmpegState.FAILED
-            if self.on_error_callback:
-                await self.on_error_callback("restart_failed")
+        if self._restart_lock.locked():
+            logger.warning("Restart already in progress.")
             return False
+        async with self._restart_lock:
+            logger.info("Restarting FFmpeg...")
+            try:
+                await self.stop()
+                return await self.start()
+            except Exception as e:
+                logger.error(f"Error during FFmpeg restart: {e}")
+                async with self._state_lock:
+                    self.state = FFmpegState.FAILED
+                if self.on_error_callback:
+                    await self.on_error_callback("restart_failed")
+                return False
 
     async def _drain_stderr(self):
         try:
             while True:
                 if not self.process or not self.process.stderr:
                     break
-                line = await self.process.stderr.readline()
+                line = await self.process.stderr.read(65536)
                 if not line:
                     break
                 logger.debug(f"FFmpeg stderr: {line.decode(errors='ignore').strip()}")

--- a/whisperlivekit/metrics_collector.py
+++ b/whisperlivekit/metrics_collector.py
@@ -24,6 +24,8 @@ class SessionMetrics:
     n_transcription_calls: int = 0
     n_tokens_produced: int = 0
     n_responses_sent: int = 0
+    backpressure_wait_s: float = 0.0
+    peak_queued_audio_s: float = 0.0
 
     # Keep recent calls for the p95 without retaining an entire long session.
     transcription_durations: Deque[float] = field(default_factory=lambda: deque(maxlen=4096))
@@ -69,6 +71,8 @@ class SessionMetrics:
             "n_transcription_calls": self.n_transcription_calls,
             "n_tokens_produced": self.n_tokens_produced,
             "n_responses_sent": self.n_responses_sent,
+            "backpressure_wait_s": round(self.backpressure_wait_s, 3),
+            "peak_queued_audio_s": round(self.peak_queued_audio_s, 3),
             "avg_latency_ms": round(self.avg_latency_ms, 2),
             "p95_latency_ms": round(self.p95_latency_ms, 2),
             "duration_window_calls": len(self.transcription_durations),

--- a/whisperlivekit/parse_args.py
+++ b/whisperlivekit/parse_args.py
@@ -169,6 +169,15 @@ def build_parser():
     )
 
     parser.add_argument(
+        "--max-buffered-audio", type=float, default=30.0,
+        help="Maximum pending audio in seconds per processing queue (default: 30).",
+    )
+    parser.add_argument(
+        "--backpressure-timeout", type=float, default=30.0,
+        help="Fail the session if a full processing queue cannot accept work within this many seconds (default: 30).",
+    )
+
+    parser.add_argument(
         "--rest-timeout",
         type=float,
         default=0.0,

--- a/whisperlivekit/processing_queue.py
+++ b/whisperlivekit/processing_queue.py
@@ -1,0 +1,112 @@
+"""Bound pending work and wake blocked producers when a session closes."""
+
+import asyncio
+from time import perf_counter
+
+import numpy as np
+
+
+class PipelineClosed(RuntimeError):
+    pass
+
+
+class PipelineOverloaded(RuntimeError):
+    pass
+
+
+class ProcessingQueue(asyncio.Queue):
+    def __init__(self, name, *, max_samples=0, maxsize=256, timeout=30.0, on_overload=None):
+        super().__init__(maxsize=maxsize)
+        self.name = name
+        self.max_samples = max_samples
+        self.queued_samples = 0
+        self.peak_samples = 0
+        self.wait_seconds = 0.0
+        self.timeout = timeout
+        self.on_overload = on_overload
+        self.closed = False
+
+    @staticmethod
+    def _samples(item):
+        return item.size if isinstance(item, np.ndarray) else 0
+
+    def _has_space(self, item):
+        if self.closed:
+            raise PipelineClosed("Audio session is closed.")
+        return not super().full() and (
+            not self.max_samples or self.queued_samples + self._samples(item) <= self.max_samples
+        )
+
+    def full(self):
+        return super().full() or bool(self.max_samples and self.queued_samples >= self.max_samples)
+
+    async def put(self, item):
+        if self.max_samples and self._samples(item) > self.max_samples:
+            raise ValueError("Audio chunk exceeds the processing queue capacity.")
+        if self._has_space(item):
+            self.put_nowait(item)
+            return
+        started = perf_counter()
+        try:
+            async with asyncio.timeout(self.timeout):
+                while not self._has_space(item):
+                    # Use Queue's producer waiters so get()/get_nowait() wake
+                    # producers without polling or an extra task per audio chunk.
+                    waiter = self._get_loop().create_future()
+                    self._putters.append(waiter)
+                    try:
+                        await waiter
+                    except BaseException:
+                        waiter.cancel()
+                        if waiter in self._putters:
+                            self._putters.remove(waiter)
+                        self._wakeup_next(self._putters)
+                        raise
+                self.put_nowait(item)
+        except TimeoutError as exc:
+            message = f"{self.name} backlog did not clear within {self.timeout:g} seconds."
+            if self.on_overload:
+                self.on_overload(message)
+            raise PipelineOverloaded(message) from exc
+        finally:
+            self.wait_seconds += perf_counter() - started
+
+    def put_nowait(self, item):
+        if not self._has_space(item):
+            raise asyncio.QueueFull
+        # The weighted limit allows a zero-sized boundary after the last audio
+        # chunk. Queue.put_nowait uses full(), so do the ordinary insertion here.
+        self._put(item)
+        self._unfinished_tasks += 1
+        self._finished.clear()
+        self._wakeup_next(self._getters)
+
+    def _put(self, item):
+        super()._put(item)
+        self.queued_samples += self._samples(item)
+        self.peak_samples = max(self.peak_samples, self.queued_samples)
+
+    def _get(self):
+        item = super()._get()
+        self.queued_samples -= self._samples(item)
+        # Producers can have different chunk sizes. A large waiting chunk must
+        # not leave a smaller one asleep when enough room for it is available.
+        while self._putters:
+            self._wakeup_next(self._putters)
+        return item
+
+    async def get(self):
+        if self.closed and self.empty():
+            raise PipelineClosed("Audio session is closed.")
+        return await super().get()
+
+    def close(self):
+        self.closed = True
+        while not self.empty():
+            self.get_nowait()
+            self.task_done()
+        for waiters in (self._putters, self._getters):
+            while waiters:
+                waiter = waiters.popleft()
+                if not waiter.done():
+                    waiter.set_exception(PipelineClosed("Audio session is closed."))


### PR DESCRIPTION
An inference backend that falls behind currently accumulates audio without a queue limit. A disconnected client can also leave FFmpeg blocked forever on an unread output pipe. Bound pending work, propagate sustained overload to clients, and finish subprocess teardown even when the caller is cancelled.

- ASR and diarization queues hold at most 30 seconds of audio by default. Producers wait for capacity without dropping samples. All processing queues, including translation, also have a 256-item limit. A 30-second wait timeout ends the session with HTTP 503 or a WebSocket error and close code 1011. Both time limits are configurable.
- Split large PCM messages before enqueueing, preserve EOF and silence boundaries, and wake blocked producers and consumers during cleanup. Log the peak queued audio and cumulative producer wait in session metrics.
- Drain abandoned FFmpeg output, then terminate and kill the process if needed. Concurrent stop calls share cleanup; normal EOF still consumes the decoded audio before stopping.

Four scenario tests cover real FFmpeg teardown, sample preservation and session isolation under load, timeout/cancellation, and overload responses through REST, native WebSocket and Deepgram. This bounds pending processing queues; model buffers, uploads, translation-backend history and full transcript history retain their existing lifetimes.

Related to the memory concerns in #344; preserves the full-history behavior required by #372. These are historical context, not claims to resolve every memory issue. This also needs to be preserved when rebasing #395.

Validation:
- Ruff and whitespace checks pass.
- Regression suite: 302 passed, 15 skipped locally; 303 passed, 14 skipped on CI Linux.
- Real-audio scenarios: 17 passed (Whisper backend matrix and streaming coalescence/boundaries).
- Wheel and source distribution build successfully.
- CPU ARM64 and CUDA AMD64 Docker images build and start. All eight changed runtime modules in both installed packages match the source commit; all four new scenario tests pass inside each image.
- The CPU image transcribes real audio through REST and WebSocket, including FFmpeg decoding and EOF drainage. The CUDA image imports Torch/Torchaudio 2.11.0+cu129 and CTranslate2, and serves REST/WebSocket in no-transcription mode under emulation. NVIDIA inference and the optional Qwen3/Sortformer image variants were not validated.
- All GitHub checks pass, including real-audio streaming, Python 3.11/3.12/3.13 imports, Diart compatibility and CodeQL. CI explicitly installs FFmpeg to exercise the subprocess and REST integration scenarios.

The README is unchanged.
