### PR TITLE
Separate audio input and translation from session orchestration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Follow [CONTRIBUTING.md](CONTRIBUTING.md) for setup, validation, and test scope.
 ## Runtime boundaries
 
 - `TranscriptionEngine` loads models during startup and is shared within one process. `reset()` is for tests and backend comparisons.
-- `AudioProcessor` is per session. It owns audio queues, buffers, and processing tasks. Always call `cleanup()` when leaving a session.
+- `AudioProcessor` is per session. It owns the sample clock, segmentation, queues, shared state and task lifecycle. `AudioInput` owns PCM buffering and decoding; `run_translation()` consumes translation events. Neither imports the orchestrator. Always call `cleanup()` when leaving a session.
 - `WhisperLiveKitConfig` describes configuration. `parse_args()` returns this dataclass; `engine.args` is a compatibility namespace.
 - `online_factory()` selects the session processor. Use `SessionASRProxy` or the backend's session wrapper for language/context overrides; do not mutate shared ASR state directly.
 - `FrontData.to_dict()` defines native WebSocket JSON. The browser uses full snapshots; diff mode is opt-in for custom clients.
@@ -16,7 +16,7 @@ Follow [CONTRIBUTING.md](CONTRIBUTING.md) for setup, validation, and test scope.
 | Area | Entry points |
 |---|---|
 | Server and protocol adapters | `basic_server.py`, `deepgram_compat.py`, `docs/API.md` |
-| Streaming pipeline | `audio_processor.py`, `tokens_alignment.py`, `timed_objects.py` |
+| Streaming pipeline | `audio_processor.py`, `audio_input.py`, `translation_processor.py`, `tokens_alignment.py` |
 | Backend construction | `core.py`, `simul_whisper/`, `local_agreement/` |
 | CLI and configuration | `cli.py`, `parse_args.py`, `config.py` |
 | Real-audio testing | `test_harness.py`, `tests/test_pipeline.py`, `tests/test_asr_coalescing_pipeline.py` |

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -870,53 +870,25 @@ class FakeFFmpegManager:
 
 
 @pytest.mark.asyncio
-async def test_process_audio_non_pcm_closes_ffmpeg_stdin_without_sentinel():
-    from whisperlivekit.audio_processor import AudioProcessor
+async def test_encoded_input_drains_temporary_empty_reads_and_tail_before_eof():
+    from whisperlivekit.audio_input import AudioInput
 
-    processor = object.__new__(AudioProcessor)
-    processor.beg_loop = 1.0
-    processor.is_stopping = False
-    processor.is_pcm_input = False
-    processor.ffmpeg_manager = FakeFFmpegManager()
-    processor.transcription_queue = asyncio.Queue()
-    processor.pcm_buffer = bytearray()
-
-    await processor.process_audio(b"")
-
-    assert processor.is_stopping is True
-    assert processor.ffmpeg_manager.closed is True
-    assert processor.transcription_queue.empty()
-
-
-@pytest.mark.asyncio
-async def test_ffmpeg_reader_drains_stdout_after_stop_before_sentinel():
-    from whisperlivekit.audio_processor import SENTINEL, AudioProcessor
-
-    processor = object.__new__(AudioProcessor)
-    processor.is_stopping = True
-    processor.ffmpeg_manager = FakeFFmpegManager([b"aaaa", None, b"bbbb", b""])
-    processor.max_bytes_per_sec = 160000
-    processor.pcm_buffer = bytearray()
-    processor.transcription_queue = asyncio.Queue()
-    processor.diarization_queue = None
-    processor.translation_queue = None
-    processor.diarization = None
-    processor.translation = None
-    processor.bytes_per_sample = 2
-    seen = []
-
-    async def fake_handle_pcm_data():
-        seen.append(bytes(processor.pcm_buffer))
-        processor.pcm_buffer.clear()
-
-    processor.handle_pcm_data = fake_handle_pcm_data
-
-    await processor.ffmpeg_stdout_reader()
-
-    assert seen == [b"aaaa", b"bbbb"]
-    assert processor.ffmpeg_manager.stopped is True
-    assert await processor.transcription_queue.get() is SENTINEL
-    assert processor.transcription_queue.empty()
+    seen, boundaries = [], []
+    async def on_pcm(chunk):
+        seen.append(chunk)
+    async def on_eof():
+        boundaries.append(sum(len(chunk) for chunk in seen))
+    audio = AudioInput(pcm_input=False, sample_rate=16000, channels=1,
+                       chunk_bytes=3200, max_chunk_bytes=16000,
+                       on_pcm=on_pcm, on_eof=on_eof)
+    audio.decoder = FakeFFmpegManager([b"aaaa", None, b"bbbb", b""])
+    await audio.finish()
+    assert audio.decoder.closed and not boundaries
+    await audio.read()
+    np.testing.assert_array_equal(np.concatenate(seen), np.frombuffer(b"aaaabbbb", dtype="<i2") / 32768.0)
+    assert boundaries == [4] and audio.decoder.stopped
+    await audio.finish()
+    assert boundaries == [4]
 
 
 def test_concatenate_diar_segments_does_not_mutate_stored_segments():

--- a/tests/test_deepgram_compat.py
+++ b/tests/test_deepgram_compat.py
@@ -1437,7 +1437,7 @@ async def test_transcription_ready_event_waits_for_matching_snapshot():
     processor = object.__new__(AudioProcessor)
     processor.stream_event_queue = asyncio.Queue()
     processor._stream_events_after_snapshot = asyncio.Queue()
-    processor._ffmpeg_error = None
+    processor.audio_input = SimpleNamespace(error=None)
     processor.tokens_alignment = SimpleNamespace(
         update=lambda: None,
         get_lines=lambda **kwargs: ([], "", ""),

--- a/tests/test_pause_segmentation.py
+++ b/tests/test_pause_segmentation.py
@@ -8,8 +8,8 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from whisperlivekit.audio_input import AudioInput
 from whisperlivekit.audio_processor import (
-    MIN_DURATION_REAL_SILENCE,
     SENTINEL,
     AudioProcessor,
 )
@@ -26,13 +26,6 @@ from whisperlivekit.timed_objects import (
     Transcript,
 )
 from whisperlivekit.tokens_alignment import TokensAlignment
-
-
-def test_pause_segmentation_config_preserves_default():
-    config = WhisperLiveKitConfig()
-
-    assert config.pause_segmentation_seconds == 5.0
-    assert config.pause_segmentation_seconds == MIN_DURATION_REAL_SILENCE
 
 
 @pytest.mark.parametrize("value", [-0.1, math.inf, -math.inf, math.nan, "invalid"])
@@ -58,6 +51,11 @@ def _silence_processor(threshold: float) -> AudioProcessor:
     processor.diarization_queue = None
     processor.translation_queue = None
     processor.vac = lambda _pcm: []
+    processor.audio_input = AudioInput(
+        pcm_input=True, sample_rate=100, channels=1, chunk_bytes=100, max_chunk_bytes=1000,
+        on_pcm=processor._process_pcm_array, on_eof=processor._finish_input,
+    )
+    processor.pcm_buffer = processor.audio_input.buffer
     return processor
 
 
@@ -193,7 +191,7 @@ async def test_eof_tail_extends_active_silence_before_committing_boundary():
     processor.current_silence = Silence(start=0.4, is_starting=True)
     processor.total_pcm_samples = 100
     processor.bytes_per_sample = 2
-    processor.pcm_buffer = bytearray(np.zeros(10, dtype=np.int16).tobytes())
+    processor.pcm_buffer[:] = bytearray(np.zeros(10, dtype=np.int16).tobytes())
     enqueued_audio = []
 
     async def capture_audio(chunk):
@@ -219,7 +217,7 @@ async def test_eof_tail_honors_vad_speech_start_and_enqueues_active_suffix():
     processor.current_silence = Silence(start=0.4, is_starting=True)
     processor.total_pcm_samples = 100
     processor.bytes_per_sample = 2
-    processor.pcm_buffer = bytearray(np.arange(10, dtype=np.int16).tobytes())
+    processor.pcm_buffer[:] = bytearray(np.arange(10, dtype=np.int16).tobytes())
     processor.vac = lambda _pcm: [{"start": 105}]
     enqueued_audio = []
 
@@ -246,7 +244,7 @@ async def test_eof_commits_active_pause_without_complete_pcm_sample(pcm_tail):
     processor.current_silence = Silence(start=0.3, is_starting=True)
     processor.total_pcm_samples = 100
     processor.bytes_per_sample = 2
-    processor.pcm_buffer = bytearray(pcm_tail)
+    processor.pcm_buffer[:] = bytearray(pcm_tail)
     processor.beg_loop = 1.0
     processor.is_stopping = False
     processor.is_pcm_input = True
@@ -351,7 +349,7 @@ async def test_full_mode_formatter_does_not_publish_in_progress_pause():
     processor.state = State(new_tokens=[ASRToken(0.0, 1.0, "speech")])
     processor.tokens_alignment = TokensAlignment(processor.state, processor.args, " ")
     processor.translation = None
-    processor._ffmpeg_error = None
+    processor.audio_input = SimpleNamespace(error=None)
     processor.last_response_content = FrontData()
     processor.metrics = SessionMetrics()
     processor.is_stopping = False

--- a/whisperlivekit/audio_input.py
+++ b/whisperlivekit/audio_input.py
@@ -1,0 +1,98 @@
+"""Bound PCM buffering and drain encoded input before signaling audio EOF."""
+
+import asyncio
+import logging
+from time import monotonic
+
+import numpy as np
+
+from whisperlivekit.ffmpeg_manager import FFmpegManager, FFmpegState
+from whisperlivekit.processing_queue import PipelineClosed, PipelineOverloaded
+
+logger = logging.getLogger(__name__)
+
+
+class AudioInput:
+    def __init__(self, *, pcm_input, sample_rate, channels, chunk_bytes,
+                 max_chunk_bytes, on_pcm, on_eof):
+        self.buffer = bytearray()
+        self.chunk_bytes = min(chunk_bytes, max_chunk_bytes)
+        self.max_chunk_bytes = max_chunk_bytes
+        self.on_pcm, self.on_eof = on_pcm, on_eof
+        self.error = None
+        self.finished = False
+        self.decoder = None if pcm_input else FFmpegManager(sample_rate, channels)
+        if self.decoder:
+            self.decoder.on_error_callback = self._decoder_error
+
+    async def _decoder_error(self, error):
+        self.error = error
+        logger.error("FFmpeg error: %s", error)
+
+    async def write(self, message):
+        if self.finished:
+            return
+        if self.decoder:
+            if not await self.decoder.write_data(message):
+                await self._decoder_error("write_error")
+            return
+        view = memoryview(message)
+        for offset in range(0, len(view), self.max_chunk_bytes):
+            self.buffer.extend(view[offset:offset + self.max_chunk_bytes])
+            await self.drain()
+
+    async def drain(self, *, final=False):
+        while len(self.buffer) >= (2 if final else self.chunk_bytes):
+            size = min(len(self.buffer), self.max_chunk_bytes) // 2 * 2
+            if not size:
+                break
+            pcm = np.frombuffer(self.buffer[:size], dtype="<i2").astype(np.float32) / 32768.0
+            del self.buffer[:size]
+            await self.on_pcm(pcm)
+
+    async def finish(self):
+        if self.finished:
+            return
+        self.finished = True
+        if self.decoder:
+            # The reader owns decoded EOF. Closing stdin must not discard stdout.
+            await self.decoder.close_stdin()
+        else:
+            await self.drain(final=True)
+            await self.on_eof()
+
+    async def read(self):
+        """Read decoder output; cancellation leaves cleanup to the orchestrator."""
+        previous = monotonic()
+        try:
+            while True:
+                state = await self.decoder.get_state()
+                if state in (FFmpegState.FAILED, FFmpegState.STOPPED):
+                    break
+                if state != FFmpegState.RUNNING:
+                    await asyncio.sleep(0.1)
+                    continue
+                now = monotonic()
+                size = min(max(int(32000 * (now - previous)), 4096), self.max_chunk_bytes)
+                previous = now
+                chunk = await self.decoder.read_data(size)
+                if chunk is None:
+                    if self.error:
+                        break
+                    await asyncio.sleep(0.05)
+                    continue
+                if not chunk:
+                    break
+                self.buffer.extend(chunk)
+                await self.drain()
+            await self.drain(final=True)
+            await self.decoder.stop()
+            await self.on_eof()
+        except (PipelineClosed, PipelineOverloaded):
+            # Release an encoded producer blocked in stdin.drain().
+            await self.decoder.stop()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            await self._decoder_error(str(exc))
+            await self.decoder.stop()

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -8,6 +8,7 @@ from typing import Any, AsyncGenerator, List, Optional, Union
 
 import numpy as np
 
+from whisperlivekit.audio_input import AudioInput
 from whisperlivekit.config import validate_pause_segmentation_seconds
 from whisperlivekit.core import (
     TranscriptionEngine,
@@ -15,9 +16,14 @@ from whisperlivekit.core import (
     online_factory,
     online_translation_factory,
 )
-from whisperlivekit.ffmpeg_manager import FFmpegManager, FFmpegState
 from whisperlivekit.metrics_collector import SessionMetrics
-from whisperlivekit.processing_queue import PipelineClosed, PipelineOverloaded, ProcessingQueue
+from whisperlivekit.processing_queue import (
+    SENTINEL,
+    PipelineClosed,
+    PipelineOverloaded,
+    ProcessingQueue,
+    get_all_from_queue,
+)
 from whisperlivekit.silero_vad_iterator import FixedVADIterator, OnnxWrapper, load_jit_vad
 from whisperlivekit.timed_objects import (
     ASRToken,
@@ -30,10 +36,10 @@ from whisperlivekit.timed_objects import (
     Transcript,
 )
 from whisperlivekit.tokens_alignment import TokensAlignment, resolve_retention_seconds
+from whisperlivekit.translation_processor import run_translation
 
 logger = logging.getLogger(__name__)
 
-SENTINEL = object() # unique sentinel object for end of stream marker
 MIN_DURATION_REAL_SILENCE = 5
 
 
@@ -61,34 +67,6 @@ def should_defer_inference(deferred_s: float, chunk_s: float, min_s: float) -> b
     if min_s <= 0.0:
         return False
     return deferred_s + chunk_s < min_s
-
-async def get_all_from_queue(
-    queue: asyncio.Queue,
-) -> Union[object, Silence, ChangeSpeaker, np.ndarray, List[Any]]:
-    items: List[Any] = []
-
-    first_item = await queue.get()
-    queue.task_done()
-    if first_item is SENTINEL:
-        return first_item
-    if isinstance(first_item, (Silence, ChangeSpeaker)):
-        return first_item
-    items.append(first_item)
-
-    while True:
-        if not queue._queue:
-            break
-        next_item = queue._queue[0]
-        if next_item is SENTINEL:
-            break
-        if isinstance(next_item, (Silence, ChangeSpeaker)):
-            break
-        items.append(await queue.get())
-        queue.task_done()
-    if isinstance(items[0], np.ndarray):
-        return np.concatenate(items)
-    else: #translation
-        return items
 
 class AudioProcessor:
     """
@@ -169,19 +147,13 @@ class AudioProcessor:
                 self.vac = FixedVADIterator(vac_model)
             else:
                 self.vac = FixedVADIterator(load_jit_vad())
-        self.ffmpeg_manager: Optional[FFmpegManager] = None
+        self.audio_input = AudioInput(
+            pcm_input=self.is_pcm_input, sample_rate=self.sample_rate, channels=self.channels,
+            chunk_bytes=self.bytes_per_sec, max_chunk_bytes=self.max_bytes_per_sec,
+            on_pcm=self._process_pcm_array, on_eof=self._finish_input,
+        )
+        self.ffmpeg_manager = self.audio_input.decoder
         self.ffmpeg_reader_task: Optional[asyncio.Task] = None
-        self._ffmpeg_error: Optional[str] = None
-
-        if not self.is_pcm_input:
-            self.ffmpeg_manager = FFmpegManager(
-                sample_rate=self.sample_rate,
-                channels=self.channels
-            )
-            async def handle_ffmpeg_error(error_type: str):
-                logger.error(f"FFmpeg error: {error_type}")
-                self._ffmpeg_error = error_type
-            self.ffmpeg_manager.on_error_callback = handle_ffmpeg_error
 
         self.overload_error: Optional[str] = None
         queue_options = {
@@ -199,7 +171,7 @@ class AudioProcessor:
         self.translation_queue = (
             ProcessingQueue("Translation", **queue_options) if self.args.target_language else None
         )
-        self.pcm_buffer: bytearray = bytearray()
+        self.pcm_buffer = self.audio_input.buffer
         self.total_pcm_samples: int = 0
         self.transcription_task: Optional[asyncio.Task] = None
         self.diarization_task: Optional[asyncio.Task] = None
@@ -511,60 +483,10 @@ class AudioProcessor:
         self.state.tokens = self.state.tokens[-1:]
 
     async def ffmpeg_stdout_reader(self) -> None:
-        """Read audio data from FFmpeg stdout and process it into the PCM pipeline."""
-        beg = time()
-        cancelled = False
-        while True:
-            try:
-                state = await self.ffmpeg_manager.get_state() if self.ffmpeg_manager else FFmpegState.STOPPED
-                if state == FFmpegState.FAILED:
-                    logger.error("FFmpeg is in FAILED state, cannot read data")
-                    break
-                elif state == FFmpegState.STOPPED:
-                    logger.info("FFmpeg is stopped")
-                    break
-                elif state != FFmpegState.RUNNING:
-                    await asyncio.sleep(0.1)
-                    continue
+        await self.audio_input.read()
 
-                current_time = time()
-                elapsed_time = max(0.0, current_time - beg)
-                buffer_size = min(max(int(32000 * elapsed_time), 4096), self.max_bytes_per_sec)
-                beg = current_time
-
-                chunk = await self.ffmpeg_manager.read_data(buffer_size)
-                if chunk is None:
-                    await asyncio.sleep(0.05)
-                    continue
-                if chunk == b"":
-                    logger.info("FFmpeg stdout reached EOF.")
-                    break
-
-                self.pcm_buffer.extend(chunk)
-                await self.handle_pcm_data()
-
-            except asyncio.CancelledError:
-                logger.info("ffmpeg_stdout_reader cancelled.")
-                cancelled = True
-                break
-            except (PipelineClosed, PipelineOverloaded):
-                # Encoded input may still be blocked in stdin.drain(). Reap
-                # the decoder now so that producer can reach session cleanup.
-                await self.ffmpeg_manager.stop()
-                return
-            except Exception as e:
-                logger.warning(f"Exception in ffmpeg_stdout_reader: {e}")
-                logger.debug(f"Traceback: {traceback.format_exc()}")
-                await asyncio.sleep(0.2)
-
-        if cancelled:
-            return
-
-        await self._flush_remaining_pcm()
-        if self.ffmpeg_manager:
-            await self.ffmpeg_manager.stop()
-
-        logger.info("FFmpeg stdout processing finished. Signaling downstream processors if needed.")
+    async def _finish_input(self) -> None:
+        await self._finalize_current_silence_at_stream_end()
         await self._signal_input_complete()
 
     async def _signal_input_complete(self) -> None:
@@ -926,48 +848,7 @@ class AudioProcessor:
         logger.info("Diarization processor task finished.")
 
     async def translation_processor(self) -> None:
-        while True:
-            item = None
-            try:
-                item = await get_all_from_queue(self.translation_queue)
-                new_translation = None
-                new_translation_buffer = None
-
-                if item is SENTINEL:
-                    finalize = getattr(self.translation, "finish", self.translation.validate_buffer_and_reset)
-                    new_translation, new_translation_buffer = await asyncio.to_thread(finalize)
-                elif isinstance(item, Silence):
-                    if item.is_starting:
-                        new_translation, new_translation_buffer = await asyncio.to_thread(
-                            self.translation.validate_buffer_and_reset
-                        )
-                    if item.has_ended:
-                        self.translation.insert_silence(item.duration)
-                elif isinstance(item, ChangeSpeaker):
-                    new_translation, new_translation_buffer = await asyncio.to_thread(
-                        self.translation.validate_buffer_and_reset
-                    )
-                else:
-                    self.translation.insert_tokens(item)
-                    new_translation, new_translation_buffer = await asyncio.to_thread(self.translation.process)
-
-                if new_translation is not None or new_translation_buffer is not None:
-                    async with self.lock:
-                        if new_translation is not None:
-                            self.state.new_translation.append(new_translation)
-                        if new_translation_buffer is not None:
-                            self.state.new_translation_buffer = new_translation_buffer
-                if item is SENTINEL:
-                    break
-            except (PipelineClosed, PipelineOverloaded):
-                return
-            except Exception as e:
-                logger.warning(f"Exception in translation_processor: {e}")
-                logger.warning(f"Traceback: {traceback.format_exc()}")
-                self.translation.error = f"Translation incomplete: {e}"
-                if item is SENTINEL:
-                    break
-        logger.info("Translation processor task finished.")
+        await run_translation(self.translation_queue, self.translation, self.state, self.lock)
 
     async def results_formatter(self) -> AsyncGenerator[FrontData, None]:
         """Format processing results for output."""
@@ -976,8 +857,8 @@ class AudioProcessor:
                 if getattr(self, "overload_error", None):
                     yield FrontData(status="error", error=self.overload_error)
                     return
-                if self._ffmpeg_error:
-                    yield FrontData(status="error", error=f"FFmpeg error: {self._ffmpeg_error}")
+                if self.audio_input.error:
+                    yield FrontData(status="error", error=f"FFmpeg error: {self.audio_input.error}")
                     return
 
                 self.tokens_alignment.update()
@@ -1173,12 +1054,7 @@ class AudioProcessor:
             logger.info("Empty audio message received, initiating stop sequence.")
             self.is_stopping = True
 
-            # Flush any remaining PCM data before signaling end-of-stream
-            if self.is_pcm_input:
-                await self._flush_remaining_pcm()
-                await self._signal_input_complete()
-            elif self.ffmpeg_manager:
-                await self.ffmpeg_manager.close_stdin()
+            await self.audio_input.finish()
 
             return
 
@@ -1188,43 +1064,10 @@ class AudioProcessor:
 
         self.metrics.n_chunks_received += 1
 
-        if self.is_pcm_input:
-            # Keep the pipeline buffer bounded even when a file client submits
-            # a large message. Waiting on a full queue slows the sender in place.
-            view = memoryview(message)
-            for offset in range(0, len(view), self.max_bytes_per_sec):
-                self.pcm_buffer.extend(view[offset:offset + self.max_bytes_per_sec])
-                await self.handle_pcm_data()
-        else:
-            if not self.ffmpeg_manager:
-                logger.error("FFmpeg manager not initialized for non-PCM input.")
-                return
-            success = await self.ffmpeg_manager.write_data(message)
-            if not success:
-                ffmpeg_state = await self.ffmpeg_manager.get_state()
-                if ffmpeg_state == FFmpegState.FAILED:
-                    logger.error("FFmpeg is in FAILED state, cannot process audio")
-                else:
-                    logger.warning("Failed to write audio data to FFmpeg")
+        await self.audio_input.write(message)
 
     async def handle_pcm_data(self) -> None:
-        # Without VAC, there's no speech detector to end the initial silence.
-        # Clear it on the first audio chunk so audio actually gets enqueued.
-        if not self.args.vac and self.current_silence:
-            await self._end_silence(speech_resumed=True)
-
-        threshold = min(self.bytes_per_sec, self.max_bytes_per_sec)
-        while len(self.pcm_buffer) >= threshold:
-            chunk_size = min(len(self.pcm_buffer), self.max_bytes_per_sec)
-            aligned_chunk_size = (chunk_size // self.bytes_per_sample) * self.bytes_per_sample
-            if aligned_chunk_size == 0:
-                return
-            pcm_array = self.convert_pcm_to_float(self.pcm_buffer[:aligned_chunk_size])
-            del self.pcm_buffer[:aligned_chunk_size]
-            await self._process_pcm_array(pcm_array)
-
-            if not self.args.transcription and not self.args.diarization:
-                await asyncio.sleep(0.1)
+        await self.audio_input.drain()
 
     async def _process_pcm_array(self, pcm_array: np.ndarray) -> None:
         """Apply VAC segmentation to one PCM array and advance stream time."""
@@ -1297,17 +1140,5 @@ class AudioProcessor:
 
     async def _flush_remaining_pcm(self) -> None:
         """Process the final PCM tail and commit any remaining pause."""
-        if not self.pcm_buffer:
-            await self._finalize_current_silence_at_stream_end()
-            return
-        aligned_size = (len(self.pcm_buffer) // self.bytes_per_sample) * self.bytes_per_sample
-        if aligned_size == 0:
-            await self._finalize_current_silence_at_stream_end()
-            return
-        while aligned_size:
-            size = min(aligned_size, self.max_bytes_per_sec)
-            pcm_array = self.convert_pcm_to_float(self.pcm_buffer[:size])
-            del self.pcm_buffer[:size]
-            await self._process_pcm_array(pcm_array)
-            aligned_size -= size
+        await self.audio_input.drain(final=True)
         await self._finalize_current_silence_at_stream_end()

--- a/whisperlivekit/processing_queue.py
+++ b/whisperlivekit/processing_queue.py
@@ -2,8 +2,13 @@
 
 import asyncio
 from time import perf_counter
+from typing import Any, List, Union
 
 import numpy as np
+
+from whisperlivekit.timed_objects import ChangeSpeaker, Silence
+
+SENTINEL = object()
 
 
 class PipelineClosed(RuntimeError):
@@ -110,3 +115,32 @@ class ProcessingQueue(asyncio.Queue):
                 waiter = waiters.popleft()
                 if not waiter.done():
                     waiter.set_exception(PipelineClosed("Audio session is closed."))
+
+
+async def get_all_from_queue(
+    queue: asyncio.Queue,
+) -> Union[object, Silence, ChangeSpeaker, np.ndarray, List[Any]]:
+    items: List[Any] = []
+
+    first_item = await queue.get()
+    queue.task_done()
+    if first_item is SENTINEL:
+        return first_item
+    if isinstance(first_item, (Silence, ChangeSpeaker)):
+        return first_item
+    items.append(first_item)
+
+    while True:
+        if not queue._queue:
+            break
+        next_item = queue._queue[0]
+        if next_item is SENTINEL:
+            break
+        if isinstance(next_item, (Silence, ChangeSpeaker)):
+            break
+        items.append(await queue.get())
+        queue.task_done()
+    if isinstance(items[0], np.ndarray):
+        return np.concatenate(items)
+    else: #translation
+        return items

--- a/whisperlivekit/translation_processor.py
+++ b/whisperlivekit/translation_processor.py
@@ -1,0 +1,56 @@
+"""Consume translation boundaries and publish results into session state."""
+
+import asyncio
+import logging
+import traceback
+
+from whisperlivekit.processing_queue import SENTINEL, PipelineClosed, PipelineOverloaded, get_all_from_queue
+from whisperlivekit.timed_objects import ChangeSpeaker, Silence
+
+logger = logging.getLogger(__name__)
+
+
+async def run_translation(queue, translation, state, lock) -> None:
+    while True:
+        item = None
+        try:
+            item = await get_all_from_queue(queue)
+            new_translation = None
+            new_translation_buffer = None
+
+            if item is SENTINEL:
+                finalize = getattr(translation, "finish", translation.validate_buffer_and_reset)
+                new_translation, new_translation_buffer = await asyncio.to_thread(finalize)
+            elif isinstance(item, Silence):
+                if item.is_starting:
+                    new_translation, new_translation_buffer = await asyncio.to_thread(
+                        translation.validate_buffer_and_reset
+                    )
+                if item.has_ended:
+                    translation.insert_silence(item.duration)
+            elif isinstance(item, ChangeSpeaker):
+                new_translation, new_translation_buffer = await asyncio.to_thread(
+                    translation.validate_buffer_and_reset
+                )
+            else:
+                translation.insert_tokens(item)
+                new_translation, new_translation_buffer = await asyncio.to_thread(translation.process)
+
+            if new_translation is not None or new_translation_buffer is not None:
+                async with lock:
+                    if new_translation is not None:
+                        state.new_translation.append(new_translation)
+                    if new_translation_buffer is not None:
+                        state.new_translation_buffer = new_translation_buffer
+            if item is SENTINEL:
+                break
+        except (PipelineClosed, PipelineOverloaded):
+            return
+        except Exception as e:
+            logger.warning(f"Exception in translation_processor: {e}")
+            logger.warning(f"Traceback: {traceback.format_exc()}")
+            translation.error = f"Translation incomplete: {e}"
+            if item is SENTINEL:
+                break
+    logger.info("Translation processor task finished.")
+


### PR DESCRIPTION
`AudioProcessor` combines decoder I/O, byte buffering, model workers and the session clock. This separates PCM/FFmpeg input into `AudioInput` and translation consumption into `run_translation()`, while the orchestrator retains sample time, segmentation, queues, shared state and task cleanup. The components receive direct callbacks or explicit state and do not import `AudioProcessor`.

This is the narrower follow-up to #395: no generic worker infrastructure, no change to REST/native WebSocket/Deepgram payloads. Encoded EOF drains stdout before signaling downstream queues; repeated EOF is idempotent, and decoder failures terminate instead of retrying indefinitely. Existing buffering limits and overload teardown remain in place.

Validation on Apple M5: default suite 308 passed/16 optional skips; four real Whisper audio scenarios for EOF, pauses and speaker boundaries; 81 MLX/Deepgram checks with the updated SDK; actual audio through REST, encoded native WebSocket and Deepgram CloseStream (one final, final word preserved). Ruff and diff checks pass. Two internal decoder checks were consolidated into one draining scenario; a constant-only test was removed.
