### PR TITLE
Fix native ASR session creation with the default streaming policy

### DIFF
--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -113,14 +113,17 @@ def test_context_only_proxy_keeps_server_language():
 
 def test_simulstreaming_context_uses_an_isolated_static_config(monkeypatch):
     import whisperlivekit.simul_whisper as simul_module
-    from whisperlivekit.core import online_factory
+    from whisperlivekit.core import SimulStreamingASR, online_factory
+
+    class RecordingSimulASR(_RecordingASR, SimulStreamingASR):
+        pass
 
     class FakeProcessor:
         def __init__(self, asr):
             self.asr = asr
 
     monkeypatch.setattr(simul_module, "SimulStreamingOnlineProcessor", FakeProcessor)
-    shared = _RecordingASR(language="en")
+    shared = RecordingSimulASR(language="en")
     shared.cfg = SimpleNamespace(
         language="en",
         static_init_prompt="global terminology",
@@ -239,3 +242,26 @@ def test_plain_session_cannot_observe_another_sessions_language_override():
         ("first", "fr", "termes\nhistorique"),
         ("second", "en", ""),
     ]
+
+
+def test_native_stream_sessions_bypass_the_default_whisper_policy(monkeypatch):
+    import sys
+    from types import ModuleType
+
+    from whisperlivekit.core import online_factory
+
+    class NativeProcessor:
+        def __init__(self, asr):
+            self.asr = asr
+            self.language = asr._session_language or asr.original_language
+
+    qwen = ModuleType('whisperlivekit.qwen3_streaming')
+    qwen.Qwen3StreamingOnlineProcessor = NativeProcessor
+    monkeypatch.setitem(sys.modules, qwen.__name__, qwen)
+    shared = _RecordingASR(language='en')
+    shared.backend_choice = 'qwen3-streaming'
+    args = SimpleNamespace(backend='qwen3-streaming', backend_policy='simulstreaming')
+    french = online_factory(args, shared, language='fr')
+    english = online_factory(args, shared, language='en')
+    assert french.language == 'fr' and english.language == 'en'
+    assert shared.original_language == 'en'

--- a/whisperlivekit/core.py
+++ b/whisperlivekit/core.py
@@ -457,9 +457,7 @@ def online_factory(args, asr, language=None, context=None):
             asr,
             language,
             context=context,
-            simulstreaming=(
-                getattr(args, "backend_policy", None) == "simulstreaming"
-            ),
+            simulstreaming=isinstance(asr, SimulStreamingASR),
         )
 
     if backend == "qwen3-streaming":


### PR DESCRIPTION
A Qwen streaming session requesting a different language could fail at construction with `AttributeError: cfg`: the factory treated the default `backend_policy=simulstreaming` as proof that the selected backend was Whisper's SimulStreaming engine.

Build an isolated Whisper config only for an actual `SimulStreamingASR`. Native streaming engines receive their session proxy directly. The existing Whisper language/context isolation remains covered, alongside a regression that creates interleaved English and French native sessions without modifying the shared engine.

Validation: 311 regression tests passed, 16 optional tests skipped; Ruff passed. No model download or dependency changes are required for this fix.
