### PR TITLE
Preserve final ASR updates and report decoder failures

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -479,6 +479,11 @@ Sent repeatedly as audio is processed. This message has **no `type` field**.
 | `remaining_time_diarization`   | float  | Seconds of audio waiting for speaker diarization. |
 | `error`                        | string | Only present when an error occurred (e.g. FFmpeg failure). |
 
+An ASR exception during decoding or EOF terminates the session with
+`status: "error"`. Keep the text already confirmed before that error; the session
+did not complete successfully. `wlk bench` retains such a sample as failed and
+excludes it from WER/CER and compute summaries.
+
 #### Line Object
 
 Each element in `lines` has the following shape:

--- a/docs/API.md
+++ b/docs/API.md
@@ -479,6 +479,9 @@ Sent repeatedly as audio is processed. This message has **no `type` field**.
 | `remaining_time_diarization`   | float  | Seconds of audio waiting for speaker diarization. |
 | `error`                        | string | Only present when an error occurred (e.g. FFmpeg failure). |
 
+The server drains final updates before closing, including when decoding finishes
+while a previous WebSocket response is being sent.
+
 An ASR exception during decoding or EOF terminates the session with
 `status: "error"`. Keep the text already confirmed before that error; the session
 did not complete successfully. `wlk bench` retains such a sample as failed and

--- a/tests/test_silent_backend_guard.py
+++ b/tests/test_silent_backend_guard.py
@@ -184,3 +184,38 @@ async def test_asr_failure_is_reported_and_keeps_the_last_confirmed_text(monkeyp
         if 'consumer' in locals():
             consumer.cancel()
             await asyncio.gather(consumer, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_formatter_drains_results_that_finish_during_a_client_send():
+    import asyncio
+    from argparse import Namespace
+    from dataclasses import asdict
+
+    from whisperlivekit.config import WhisperLiveKitConfig
+    from whisperlivekit.core import TranscriptionEngine
+    from whisperlivekit.timed_objects import ASRToken
+
+    engine = object.__new__(TranscriptionEngine)
+    engine.args = Namespace(**asdict(WhisperLiveKitConfig(transcription=False, vac=False, pcm_input=True)))
+    engine.asr = None
+    engine.translation_model = None
+    processor = AudioProcessor(transcription_engine=engine)
+    processor.transcription_task = asyncio.get_running_loop().create_future()
+    processor.state.new_tokens = [ASRToken(start=0, end=1, text='First.')]
+    output = processor.results_formatter()
+    try:
+        first = await anext(output)
+        assert ''.join(line.text for line in first.lines) == 'First.'
+        # A WebSocket send can suspend the consumer while the final ASR call
+        # finishes. That new output must be formatted before the generator ends.
+        processor.state.new_tokens = [ASRToken(start=1, end=2, text=' Last words')]
+        processor.is_stopping = True
+        processor.transcription_task.set_result(None)
+        final = await anext(output)
+        assert 'Last words' in ''.join(line.text for line in final.lines)
+        with pytest.raises(StopAsyncIteration):
+            await anext(output)
+    finally:
+        await output.aclose()
+        await processor.cleanup()

--- a/tests/test_silent_backend_guard.py
+++ b/tests/test_silent_backend_guard.py
@@ -107,3 +107,80 @@ def test_silent_backend_watchdog_respects_real_output(caplog):
     with caplog.at_level(logging.ERROR, logger="whisperlivekit.audio_processor"):
         AudioProcessor._warn_if_backend_silent(fake, 120.0)
     assert not [r for r in caplog.records if "produced no output" in r.message]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('failure_phase', ['chunk', 'eof'])
+async def test_asr_failure_is_reported_and_keeps_the_last_confirmed_text(monkeypatch, failure_phase):
+    import asyncio
+    from argparse import Namespace
+    from dataclasses import asdict
+
+    import whisperlivekit.audio_processor as processing
+    from whisperlivekit.config import WhisperLiveKitConfig
+    from whisperlivekit.core import TranscriptionEngine
+    from whisperlivekit.timed_objects import ASRToken, Transcript
+
+    class Online:
+        SAMPLING_RATE = 16000
+        asr = SimpleNamespace(sep='')
+        calls = 0
+        end = 0.0
+
+        def insert_audio_chunk(self, audio, end):
+            self.end = end
+
+        def process_iter(self, **kwargs):
+            self.calls += 1
+            if self.calls > 1 and failure_phase == 'chunk':
+                raise RuntimeError('decoder fixture failed')
+            return [ASRToken(start=0, end=self.end, text='Confirmed.')], self.end
+
+        def get_buffer(self):
+            return Transcript(start=self.end, end=self.end, text='')
+
+        def start_silence(self):
+            return [], self.end
+
+        def end_silence(self, duration, offset):
+            self.end += duration
+
+        def finish(self):
+            raise RuntimeError('decoder fixture failed')
+
+    monkeypatch.setattr(processing, 'online_factory', lambda *args, **kwargs: Online())
+    engine = object.__new__(TranscriptionEngine)
+    engine.args = Namespace(**asdict(WhisperLiveKitConfig(vac=False, pcm_input=True, min_chunk_size=0.5, asr_coalesce_min_s=0)))
+    engine.asr = SimpleNamespace()
+    engine.translation_model = None
+    processor = AudioProcessor(transcription_engine=engine)
+    records = []
+    confirmed = asyncio.Event()
+
+    async def collect(generator):
+        async for message in generator:
+            records.append(message)
+            if any(line.text == 'Confirmed.' for line in message.lines):
+                confirmed.set()
+
+    try:
+        consumer = asyncio.create_task(collect(await processor.create_tasks()))
+        await processor.process_audio(b'\x01\x00' * 8000)
+        await asyncio.wait_for(confirmed.wait(), 3)
+        if failure_phase == 'chunk':
+            await processor.process_audio(b'\x01\x00' * 8000)
+        else:
+            await processor.process_audio(b'')
+        await asyncio.wait_for(consumer, 3)
+        assert records[-1].status == 'error'
+        assert 'decoder fixture failed' in records[-1].error
+        assert any(any(line.text == 'Confirmed.' for line in r.lines) for r in records[:-1])
+        assert processor.transcription_queue.closed
+        with pytest.raises(RuntimeError, match='decoder fixture failed'):
+            await processor.process_audio(b'\x01\x00' * 8000)
+        await asyncio.wait_for(processor.transcription_task, 1)
+    finally:
+        await processor.cleanup()
+        if 'consumer' in locals():
+            consumer.cancel()
+            await asyncio.gather(consumer, return_exceptions=True)

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -156,6 +156,7 @@ class AudioProcessor:
         self.ffmpeg_reader_task: Optional[asyncio.Task] = None
 
         self.overload_error: Optional[str] = None
+        self.transcription_error: Optional[str] = None
         queue_options = {
             "timeout": getattr(self.args, "backpressure_timeout", 30.0),
             "on_overload": self._on_overload,
@@ -232,6 +233,11 @@ class AudioProcessor:
         for queue in (self.transcription_queue, self.diarization_queue, self.translation_queue):
             if isinstance(queue, ProcessingQueue):
                 queue.close()
+
+    def _fail_transcription(self, exc):
+        self.transcription_error = f"ASR failed: {type(exc).__name__}: {exc}"
+        logger.exception("Closing failed transcription session")
+        self._close_queues()
 
     async def _emit_stream_event(self, kind: str, timestamp: float) -> None:
         """Publish a protocol-neutral event on the submitted audio clock."""
@@ -602,8 +608,7 @@ class AudioProcessor:
             # End of stream finalizes the last segment even without punctuation
             await self._flush_pending_translation_tokens()
         except Exception as e:
-            logger.warning(f"Error finishing transcription: {e}")
-            logger.debug(f"Traceback: {traceback.format_exc()}")
+            self._fail_transcription(e)
 
     async def transcription_processor(self) -> None:
         """Process audio chunks for transcription."""
@@ -775,14 +780,14 @@ class AudioProcessor:
             except (PipelineClosed, PipelineOverloaded):
                 return
             except Exception as e:
-                logger.warning(f"Exception in transcription_processor: {e}")
-                logger.warning(f"Traceback: {traceback.format_exc()}")
+                self._fail_transcription(e)
+                return
 
         if self.is_stopping:
             logger.info("Transcription processor finishing due to stopping flag.")
-            if self.diarization_queue:
+            if self.diarization_queue and not getattr(self.diarization_queue, "closed", False):
                 await self.diarization_queue.put(SENTINEL)
-            if self.translation_queue:
+            if self.translation_queue and not getattr(self.translation_queue, "closed", False):
                 await self.translation_queue.put(SENTINEL)
 
         logger.info("Transcription processor task finished.")
@@ -857,6 +862,9 @@ class AudioProcessor:
                 if getattr(self, "overload_error", None):
                     yield FrontData(status="error", error=self.overload_error)
                     return
+                if getattr(self, "transcription_error", None):
+                    yield FrontData(status="error", error=self.transcription_error)
+                    return
                 if self.audio_input.error:
                     yield FrontData(status="error", error=f"FFmpeg error: {self.audio_input.error}")
                     return
@@ -914,6 +922,8 @@ class AudioProcessor:
                     pending_queue.task_done()
 
                 if self.is_stopping and self._processing_tasks_done():
+                    if getattr(self, "transcription_error", None):
+                        continue
                     logger.info("Results formatter: All upstream processors are done and in stopping state. Terminating.")
                     return
 
@@ -1044,6 +1054,9 @@ class AudioProcessor:
     async def process_audio(self, message: Optional[bytes]) -> None:
         """Process incoming audio data."""
 
+        if getattr(self, "transcription_error", None):
+            raise RuntimeError(self.transcription_error)
+
         if not self.beg_loop:
             self.beg_loop = time()
             self.metrics.session_start = self.beg_loop
@@ -1064,7 +1077,12 @@ class AudioProcessor:
 
         self.metrics.n_chunks_received += 1
 
-        await self.audio_input.write(message)
+        try:
+            await self.audio_input.write(message)
+        except PipelineClosed:
+            if getattr(self, "transcription_error", None):
+                raise RuntimeError(self.transcription_error) from None
+            raise
 
     async def handle_pcm_data(self) -> None:
         await self.audio_input.drain()

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -869,6 +869,10 @@ class AudioProcessor:
                     yield FrontData(status="error", error=f"FFmpeg error: {self.audio_input.error}")
                     return
 
+                # Completion can happen while a consumer sends the yielded
+                # response. Only end after a snapshot taken with all producers
+                # already done; otherwise their final updates need another pass.
+                upstream_done = self.is_stopping and self._processing_tasks_done()
                 self.tokens_alignment.update()
                 audio_time = (
                     self.total_pcm_samples / self.sample_rate
@@ -921,7 +925,7 @@ class AudioProcessor:
                         acknowledged.set_result(None)
                     pending_queue.task_done()
 
-                if self.is_stopping and self._processing_tasks_done():
+                if upstream_done:
                     if getattr(self, "transcription_error", None):
                         continue
                     logger.info("Results formatter: All upstream processors are done and in stopping state. Terminating.")


### PR DESCRIPTION
Final ASR output could be lost if decoding finished while a client was sending the previous response: the formatter saw completed workers and exited before building another snapshot. Separately, decoding and EOF exceptions were only logged as warnings, allowing clients and benchmarks to treat an incomplete transcript as successful.

Build a final snapshot only after observing all producers complete. Report decoding failures through the existing error status, close the processing queues, wake producers and stop the failed consumer. Keep previously published text, and retain failed benchmark samples without scoring their partial hypotheses.

Validation: 314 regression tests passed (16 optional skips). A delayed-client scenario reproduced the lost final words before the fix; complete chunk-failure and EOF-failure scenarios verify the error contract after a confirmed sentence. Ruff passed. The API documentation describes completion and failure; the README and figures are unchanged.
