### PR TITLE
Report diarization failures to clients

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -482,7 +482,7 @@ Sent repeatedly as audio is processed. This message has **no `type` field**.
 The server drains final updates before closing, including when decoding finishes
 while a previous WebSocket response is being sent.
 
-An ASR exception during decoding or EOF terminates the session with
+An ASR or diarization exception during decoding or EOF terminates the session with
 `status: "error"`. Keep the text already confirmed before that error; the session
 did not complete successfully. `wlk bench` retains such a sample as failed and
 excludes it from WER/CER and compute summaries.

--- a/tests/test_silent_backend_guard.py
+++ b/tests/test_silent_backend_guard.py
@@ -1,4 +1,4 @@
-"""Guards against silently-empty ASR output.
+"""Pipeline failure reporting and guards against silently-empty ASR output.
 
 Two real incidents motivated these: the torch 2.13 MLX device mismatch
 (#383) and CTranslate2 wheels shipping PTX newer than the GPU driver. In
@@ -219,3 +219,74 @@ async def test_formatter_drains_results_that_finish_during_a_client_send():
     finally:
         await output.aclose()
         await processor.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_phase", ["chunk", "eof"])
+async def test_diarization_failure_reaches_the_client_and_stops_input(monkeypatch, failure_phase):
+    import asyncio
+    from argparse import Namespace
+    from dataclasses import asdict
+
+    from whisperlivekit.config import WhisperLiveKitConfig
+    from whisperlivekit.core import TranscriptionEngine
+
+    class Diarizer:
+        buffer_audio = []
+
+        def __init__(self):
+            self.calls = 0
+            self.called = asyncio.Event()
+            self.closed = False
+
+        def insert_audio_chunk(self, audio):
+            pass
+
+        def insert_silence(self, duration):
+            pass
+
+        async def diarize(self):
+            self.calls += 1
+            self.called.set()
+            if failure_phase == "chunk" or self.calls > 1:
+                raise RuntimeError("speaker decoder fixture failed")
+            return []
+
+        def close(self):
+            self.closed = True
+
+    diarizer = Diarizer()
+    monkeypatch.setattr("whisperlivekit.audio_processor.online_diarization_factory", lambda *args: diarizer)
+    engine = object.__new__(TranscriptionEngine)
+    engine.args = Namespace(**asdict(WhisperLiveKitConfig(
+        transcription=False, diarization=True, vac=False, pcm_input=True, min_chunk_size=.5,
+    )))
+    engine.asr = None
+    engine.translation_model = None
+    engine.diarization_model = SimpleNamespace()
+    processor = AudioProcessor(transcription_engine=engine)
+    records = []
+
+    async def collect(generator):
+        async for response in generator:
+            records.append(response)
+
+    try:
+        consumer = asyncio.create_task(collect(await processor.create_tasks()))
+        await processor.process_audio(b"\x01\x00" * 8000)
+        await asyncio.wait_for(diarizer.called.wait(), 1)
+        if failure_phase == "eof":
+            await processor.process_audio(b"")
+        await asyncio.wait_for(consumer, 1)
+        assert records[-1].status == "error"
+        assert "speaker decoder fixture failed" in records[-1].error
+        assert processor.diarization_queue.closed
+        with pytest.raises(RuntimeError, match="speaker decoder fixture failed"):
+            await processor.process_audio(b"\x01\x00" * 8000)
+        await asyncio.wait_for(processor.diarization_task, 1)
+    finally:
+        await processor.cleanup()
+        if "consumer" in locals():
+            consumer.cancel()
+            await asyncio.gather(consumer, return_exceptions=True)
+    assert diarizer.closed

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -156,7 +156,7 @@ class AudioProcessor:
         self.ffmpeg_reader_task: Optional[asyncio.Task] = None
 
         self.overload_error: Optional[str] = None
-        self.transcription_error: Optional[str] = None
+        self.processing_error: Optional[str] = None
         queue_options = {
             "timeout": getattr(self.args, "backpressure_timeout", 30.0),
             "on_overload": self._on_overload,
@@ -234,9 +234,12 @@ class AudioProcessor:
             if isinstance(queue, ProcessingQueue):
                 queue.close()
 
-    def _fail_transcription(self, exc):
-        self.transcription_error = f"ASR failed: {type(exc).__name__}: {exc}"
-        logger.exception("Closing failed transcription session")
+    def _fail_processing(self, exc, stage="ASR"):
+        if self.processing_error:
+            return
+        self.processing_error = f"{stage} failed: {type(exc).__name__}: {exc}"
+        self.is_stopping = True
+        logger.exception("Closing failed %s session", stage)
         self._close_queues()
 
     async def _emit_stream_event(self, kind: str, timestamp: float) -> None:
@@ -608,7 +611,7 @@ class AudioProcessor:
             # End of stream finalizes the last segment even without punctuation
             await self._flush_pending_translation_tokens()
         except Exception as e:
-            self._fail_transcription(e)
+            self._fail_processing(e)
 
     async def transcription_processor(self) -> None:
         """Process audio chunks for transcription."""
@@ -780,7 +783,7 @@ class AudioProcessor:
             except (PipelineClosed, PipelineOverloaded):
                 return
             except Exception as e:
-                self._fail_transcription(e)
+                self._fail_processing(e)
                 return
 
         if self.is_stopping:
@@ -842,14 +845,14 @@ class AudioProcessor:
             except (PipelineClosed, PipelineOverloaded):
                 return
             except Exception as e:
-                logger.warning(f"Exception in diarization_processor: {e}")
-                logger.warning(f"Traceback: {traceback.format_exc()}")
+                self._fail_processing(e, stage="Diarization")
+                return
         # Drain any remaining audio in the buffer before exiting
         if has_buffer:
             try:
                 await self._drain_diarization_buffer()
             except Exception as e:
-                logger.warning(f"Exception draining diarization buffer: {e}")
+                self._fail_processing(e, stage="Diarization")
         logger.info("Diarization processor task finished.")
 
     async def translation_processor(self) -> None:
@@ -862,8 +865,8 @@ class AudioProcessor:
                 if getattr(self, "overload_error", None):
                     yield FrontData(status="error", error=self.overload_error)
                     return
-                if getattr(self, "transcription_error", None):
-                    yield FrontData(status="error", error=self.transcription_error)
+                if getattr(self, "processing_error", None):
+                    yield FrontData(status="error", error=self.processing_error)
                     return
                 if self.audio_input.error:
                     yield FrontData(status="error", error=f"FFmpeg error: {self.audio_input.error}")
@@ -926,7 +929,7 @@ class AudioProcessor:
                     pending_queue.task_done()
 
                 if upstream_done:
-                    if getattr(self, "transcription_error", None):
+                    if getattr(self, "processing_error", None):
                         continue
                     logger.info("Results formatter: All upstream processors are done and in stopping state. Terminating.")
                     return
@@ -1058,8 +1061,8 @@ class AudioProcessor:
     async def process_audio(self, message: Optional[bytes]) -> None:
         """Process incoming audio data."""
 
-        if getattr(self, "transcription_error", None):
-            raise RuntimeError(self.transcription_error)
+        if getattr(self, "processing_error", None):
+            raise RuntimeError(self.processing_error)
 
         if not self.beg_loop:
             self.beg_loop = time()
@@ -1084,8 +1087,8 @@ class AudioProcessor:
         try:
             await self.audio_input.write(message)
         except PipelineClosed:
-            if getattr(self, "transcription_error", None):
-                raise RuntimeError(self.transcription_error) from None
+            if getattr(self, "processing_error", None):
+                raise RuntimeError(self.processing_error) from None
             raise
 
     async def handle_pcm_data(self) -> None:


### PR DESCRIPTION
Speaker decoder exceptions were only logged: a chunk failure could leave the client waiting, and an EOF failure could complete without reporting that speaker attribution had failed.

Route those failures through the existing pipeline error response, close the input queues, and preserve the first failure reason. ASR and diarization share this small error handler; confirmed text already sent to clients remains valid. Translation keeps its existing separate recovery behavior. Document the session error contract.

Reproduced both failures before the change. The chunk/EOF scenario now passes, alongside the affected ASR, lifecycle, REST, native WebSocket and Deepgram regressions (109 passed locally). This validates error propagation, not NVIDIA model inference. README, badge and published figures are unchanged.
