### PR TITLE
Consolidate streaming configuration tests around behavior

### DIFF
--- a/tests/test_asr_coalescing.py
+++ b/tests/test_asr_coalescing.py
@@ -2,8 +2,6 @@
 
 import math
 
-import pytest
-
 from whisperlivekit.audio_processor import (
     resolve_coalesce_min_s,
     should_defer_inference,
@@ -11,29 +9,19 @@ from whisperlivekit.audio_processor import (
 from whisperlivekit.config import WhisperLiveKitConfig
 
 
-def test_disabled_by_default():
-    assert resolve_coalesce_min_s(WhisperLiveKitConfig().asr_coalesce_min_s) == 0.0
-
-
-def test_non_positive_and_missing_values_disable():
-    assert resolve_coalesce_min_s(0.0) == 0.0
-    assert resolve_coalesce_min_s(None) == 0.0
-
-
-def test_negative_value_warns(caplog):
-    with caplog.at_level("WARNING"):
-        assert resolve_coalesce_min_s(-1.0) == 0.0
-    assert "coalescing disabled" in caplog.text
-
-
-@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
-def test_non_finite_values_warn_and_disable(value, caplog):
-    with caplog.at_level("WARNING"):
-        resolved = resolve_coalesce_min_s(value)
-
-    assert resolved == 0.0
-    assert "non-finite" in caplog.text
-    assert should_defer_inference(1000.0, 0.5, resolved) is False
+def test_disabled_or_invalid_windows_never_defer_audio(caplog):
+    windows = [WhisperLiveKitConfig().asr_coalesce_min_s, None, 0, -1,
+               math.nan, math.inf, -math.inf]
+    for window in windows:
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            threshold = resolve_coalesce_min_s(window)
+        assert not should_defer_inference(0, .5, threshold), window
+        assert not should_defer_inference(1000, .5, threshold), window
+        if window is not None and (window < 0 or not math.isfinite(window)):
+            assert "coalescing disabled" in caplog.text, window
+        else:
+            assert not caplog.records, window
 
 
 def test_deferral_gate_honors_the_configured_window():

--- a/tests/test_translation_alignatt.py
+++ b/tests/test_translation_alignatt.py
@@ -156,9 +156,9 @@ def test_punctuation_triggers_final_segment_with_span(sidecar):
     assert buffer2.text == "AGAIN"
 
 
-def test_tail_words_are_sent_untimestamped_and_buffered(sidecar):
-    client = make_client(sidecar)  # balanced: tail on
-    assert client.wants_hypothesis_tail
+@pytest.mark.parametrize("latency", ["balanced", "quality"])
+def test_latency_preset_controls_the_uncommitted_tail_sent_to_the_sidecar(sidecar, latency):
+    client = make_client(sidecar, latency=latency)
     client.insert_tokens([
         token("Hello", 0.0, 0.4),
         HypothesisTail(start=0.5, end=1.8, text="how are"),
@@ -166,15 +166,14 @@ def test_tail_words_are_sent_untimestamped_and_buffered(sidecar):
     validated, buffer = client.process()
     assert validated is None
     update = sidecar.updates[-1]
-    assert [w[0] for w in update["tail"]["words"]] == ["how", "are"]
-    assert all(w[1] is None and w[2] is None for w in update["tail"]["words"])
+    if latency == "balanced":
+        assert [w[0] for w in update["tail"]["words"]] == ["how", "are"]
+        assert all(w[1] is None and w[2] is None for w in update["tail"]["words"])
+    else:
+        assert "tail" not in update
+    assert [w[0] for w in update["words"]] == ["Hello"]
     assert update["clock_ms"] == pytest.approx(1800.0)
     assert buffer.text == "HELLO"  # accepted only; the draft stays server-side
-
-
-def test_quality_latency_preset_disables_tail(sidecar):
-    client = make_client(sidecar, latency="quality")
-    assert client.wants_hypothesis_tail is False
 
 
 def test_pacing_skips_tail_only_updates_but_not_commits(sidecar):

--- a/whisperlivekit/test_harness.py
+++ b/whisperlivekit/test_harness.py
@@ -4,10 +4,6 @@ Wraps AudioProcessor to provide a controllable, observable interface
 for testing transcription, diarization, silence detection, and timing
 without needing a running server or WebSocket connection.
 
-Designed for use by AI agents: feed audio with timeline control,
-inspect state at any point, pause/resume to test silence detection,
-cut to test abrupt termination.
-
 Usage::
 
     import asyncio


### PR DESCRIPTION
Replace isolated configuration-field checks with behavior checks in two recently modified streaming paths. Disabled, missing and invalid coalescing windows share one scenario that verifies audio is never deferred and invalid settings produce a warning. The translation latency preset is checked against the actual sidecar update: quality mode omits the unstable tail while still sending confirmed words.

The same default, negative, NaN and infinity cases remain covered. EOF, speaker boundaries, timestamp and session-isolation regressions remain in place. Remove the test harness docstring's unnecessary reference to AI agents.

Validation: coalescing, boundary and AlignAtt client scenarios passed locally (24 passed, 2 optional skips); Ruff and diff checks passed. Runtime behavior, README, badge and published figures are unchanged.
