### PR TITLE
Allow translation cancellation when inference workers are occupied

### DIFF
--- a/docs/translation-mlx.md
+++ b/docs/translation-mlx.md
@@ -33,5 +33,6 @@ can keep ASR and translation dependencies in separate processes.
 If generation fails, `translation_error` reports the incomplete translation and
 ASR can continue. A failed sentence stays queued for retry; successful sentences
 are published once. An empty model response is an error, and untranslated source
-words are never shown as translated output. Cleanup interrupts generation at the
-next generated token.
+words are never shown as translated output. Disconnecting a client interrupts
+generation at the next generated token, including when inference workers are
+fully occupied by other sessions.

--- a/tests/test_streaming_lifecycle.py
+++ b/tests/test_streaming_lifecycle.py
@@ -4,7 +4,9 @@ import asyncio
 import io
 import shutil
 import sys
+import threading
 import wave
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import numpy as np
@@ -109,6 +111,40 @@ def engine(monkeypatch):
         lambda *args, **kwargs: SimpleNamespace(asr=SimpleNamespace(sep=" ")),
     )
     return shared
+
+
+def test_translation_cleanup_can_interrupt_a_saturated_inference_pool(engine):
+    from whisperlivekit.translation_mlx_llm_mt import MlxLlmTranslation
+
+    async def scenario():
+        # A single occupied worker reproduces starvation at any pool size.
+        with ThreadPoolExecutor(max_workers=1) as inference:
+            asyncio.get_running_loop().set_default_executor(inference)
+            processor = AudioProcessor(transcription_engine=engine)
+            translation = MlxLlmTranslation(source_language="en", target_language="zh", warmup=False)
+            processor.translation = translation
+            started = threading.Event()
+
+            def generate_until_cancelled():
+                started.set()
+                if not translation._closed.wait(5):
+                    raise TimeoutError("Translation was not interrupted")
+
+            worker = asyncio.create_task(asyncio.to_thread(generate_until_cancelled))
+            processor.all_tasks_for_cleanup = [worker]
+            try:
+                async with asyncio.timeout(1):
+                    while not started.is_set():
+                        await asyncio.sleep(.01)
+                    await processor.cleanup()
+                    assert worker.done()
+                    # Cancellation must release the inference worker for other sessions.
+                    assert await asyncio.to_thread(lambda: "available") == "available"
+            finally:
+                translation.close()
+                await asyncio.gather(worker, return_exceptions=True)
+
+    asyncio.run(scenario())
 
 
 @pytest.mark.asyncio

--- a/tests/test_translation_alignatt.py
+++ b/tests/test_translation_alignatt.py
@@ -353,5 +353,7 @@ def test_translation_processor_plumbing_with_fake_sidecar(sidecar):
     assert processor.state.new_translation, "no validated translation produced"
     assert " ".join(t.text for t in processor.state.new_translation) == "HELLO WORLD. [F] LAST WORDS [F]"
     assert processor.translation._pending_finals == []
-    processor.translation.close()
+    from whisperlivekit.translation_processor import close_translation
+
+    asyncio.run(close_translation(processor.translation))
     assert processor.translation._ws is None

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -36,7 +36,7 @@ from whisperlivekit.timed_objects import (
     Transcript,
 )
 from whisperlivekit.tokens_alignment import TokensAlignment, resolve_retention_seconds
-from whisperlivekit.translation_processor import run_translation
+from whisperlivekit.translation_processor import close_translation, run_translation
 
 logger = logging.getLogger(__name__)
 
@@ -1014,12 +1014,10 @@ class AudioProcessor:
         logger.info("Starting cleanup of AudioProcessor resources.")
         self.is_stopping = True
         self._close_queues()
-        close_translation = getattr(self.translation, "close", None)
-        if close_translation is not None:
-            try:
-                await asyncio.to_thread(close_translation)
-            except Exception:
-                logger.exception("Failed to close translation connection")
+        try:
+            await close_translation(self.translation)
+        except Exception:
+            logger.exception("Failed to close translation connection")
         for task in self.all_tasks_for_cleanup:
             if task and not task.done():
                 task.cancel()

--- a/whisperlivekit/translation_processor.py
+++ b/whisperlivekit/translation_processor.py
@@ -3,11 +3,22 @@
 import asyncio
 import logging
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 
 from whisperlivekit.processing_queue import SENTINEL, PipelineClosed, PipelineOverloaded, get_all_from_queue
 from whisperlivekit.timed_objects import ChangeSpeaker, Silence
 
 logger = logging.getLogger(__name__)
+
+# Closing a translation interrupts inference. It must not queue behind the
+# inference jobs it needs to stop. Remote socket closes have a bounded timeout.
+_CLOSE_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wlk-translation-close")
+
+
+async def close_translation(translation) -> None:
+    close = getattr(translation, "close", None)
+    if close is not None:
+        await asyncio.get_running_loop().run_in_executor(_CLOSE_EXECUTOR, close)
 
 
 async def run_translation(queue, translation, state, lock) -> None:
@@ -53,4 +64,3 @@ async def run_translation(queue, translation, state, lock) -> None:
             if item is SENTINEL:
                 break
     logger.info("Translation processor task finished.")
-


### PR DESCRIPTION
Closing a translation was submitted to the same executor as inference. When every worker was occupied, cancellation queued behind the generation it needed to interrupt, so a disconnected session could remain stuck.

Run translation closure in a small, separate executor. AudioProcessor keeps its existing cleanup order and error handling; translators retain their synchronous close and result contracts. This also keeps a remote WebSocket close off the event loop.

Validation: a saturated-pool scenario fails with a cleanup timeout before this change and passes afterward, releasing the inference worker. The 17 affected lifecycle/remote-translation scenarios pass. The existing sidecar scenario now exercises the same closure path; that scenario and the saturation regression pass on the final code. Ruff and diff checks pass. The root README and benchmark figures are unchanged.
