### PR TITLE
Honor direct English translation in Whisper MLX

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -12,6 +12,10 @@ wlk --backend mlx-whisper --backend-policy localagreement --language fr --direct
 ```
 
 Without `--direct-english-translation`, it transcribes in the source language.
+This MLX mode has not passed real-audio validation: the tested Whisper small
+snapshot produces repetitive or incorrect translations on French and Chinese
+FLEURS clips, including incorrect translations outside WLK. Forwarding the
+decoding task fixes the ignored option but does not establish translation quality.
 Translated word timestamps are approximate; Whisper does not provide reliable
 word alignment for translated speech. Translation into other languages uses the
 [separate translation stage](translation-mlx.md).

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -2,6 +2,20 @@
 
 Choose a backend for the hardware and languages you need. Installation extras are declared in [pyproject.toml](../pyproject.toml).
 
+## Whisper MLX direct translation
+
+With LocalAgreement on Apple Silicon, Whisper MLX can translate speech directly
+into English. Set the source language with `--language`:
+
+```bash
+wlk --backend mlx-whisper --backend-policy localagreement --language fr --direct-english-translation
+```
+
+Without `--direct-english-translation`, it transcribes in the source language.
+Translated word timestamps are approximate; Whisper does not provide reliable
+word alignment for translated speech. Translation into other languages uses the
+[separate translation stage](translation-mlx.md).
+
 ## Voxtral Backend
 
 WhisperLiveKit supports [Voxtral Mini](https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602),

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,10 +2,40 @@
 
 import asyncio
 import sys
+from dataclasses import asdict
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
+
+
+def test_mlx_direct_translation_preserves_source_language_and_filters_vad(monkeypatch):
+    from whisperlivekit.config import WhisperLiveKitConfig
+    from whisperlivekit.local_agreement import whisper_online
+    from whisperlivekit.local_agreement.backends import MLXWhisper
+
+    def load_model(self, *args):
+        self.model_size_or_path = "local-whisper"
+
+        def transcribe(audio, *, language, **options):
+            assert language == "fr"
+            assert "vad_filter" not in options
+            text = " Hello." if options.get("task") == "translate" else " Bonjour."
+            return {"segments": [{"words": [{"start": 0, "end": 1, "word": text}]}]}
+
+        return transcribe
+
+    monkeypatch.setattr(MLXWhisper, "load_model", load_model)
+    monkeypatch.setattr(whisper_online, "mlx_backend_available", lambda **kwargs: True)
+    for translate, expected in [(False, " Bonjour."), (True, " Hello.")]:
+        config = WhisperLiveKitConfig(
+            backend="mlx-whisper", lan="fr", model_size="tiny",
+            direct_english_translation=translate, warmup_file="",
+        )
+        asr = whisper_online.backend_factory(**asdict(config))
+        asr.use_vad()
+        words = asr.ts_words(asr.transcribe(np.zeros(16000, dtype=np.float32)))
+        assert "".join(word.text for word in words) == expected
 
 
 def _base_simul_kwargs(**overrides):

--- a/whisperlivekit/local_agreement/backends.py
+++ b/whisperlivekit/local_agreement/backends.py
@@ -188,8 +188,9 @@ class MLXWhisper(ASRBase):
             raise ValueError(f"Model name '{model_name}' is not recognized or not supported.")
 
     def transcribe(self, audio, init_prompt=""):
-        if self.transcribe_kargs:
-            logger.warning("Transcribe kwargs (vad, task) are not compatible with MLX Whisper and will be ignored.")
+        options = dict(self.transcribe_kargs)
+        options.pop("vad", None)
+        options.pop("vad_filter", None)
         segments = self.model(
             audio,
             language=self.original_language,
@@ -197,6 +198,7 @@ class MLXWhisper(ASRBase):
             word_timestamps=True,
             condition_on_previous_text=True,
             path_or_hf_repo=self.model_size_or_path,
+            **options,
         )
         return segments.get("segments", [])
 


### PR DESCRIPTION
Whisper MLX ignored `--direct-english-translation` because its adapter discarded every decoding option, including the supported `task="translate"`. Forward decoding options while filtering the unsupported VAD flags. One factory-to-adapter scenario fails before the fix and passes afterward; all 35 backend tests, Ruff and the implementation commit's GitHub checks pass.

Keep this PR in draft: real-audio validation failed on the French and Chinese FLEURS recording with sentence ID 1682. The Chinese stream starts in English, then repeats Chinese characters; the French stream repeats “Moses” and contains mistranslations. Full-recording calls to upstream mlx-whisper also produce an English loop for Chinese and mistranslations for French, both with and without word timestamps. This is not solely a word-timestamp conversion defect, and forwarding the task does not make the mode reliable.

The documentation states this limitation. References, audio/model identities, runtime, source commit and original outputs are retained in the [evaluation evidence](https://github.com/QuentinFuxa/WhisperLiveKit/blob/66d00a0/benchmarks/evaluations/m5-20260907/REVIEW.md). Further diagnosis and a usable real-audio configuration are required before fusion; no model-quality pass is claimed.
