### PR TITLE
feat: MLX-native sortformer diarization backend (pure MLX, no NeMo)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ diarization-sortformer = [
     "nemo-toolkit[asr]>=3.0,<4",
     "onnx>=1.22.0",
 ]
+diarization-mlx-sortformer = [
+    'mlx-audio>=0.4.4,<0.5; sys_platform == "darwin" and platform_machine == "arm64"',
+]
 canary = [
     "nemo-toolkit[asr]>=3.0,<4",
     "kaldialign>=0.12.0",

--- a/tests/test_diarization_mlx_backend.py
+++ b/tests/test_diarization_mlx_backend.py
@@ -1,0 +1,164 @@
+"""Contract tests for the MLX Sortformer diarization backend.
+
+The backend's mlx-audio dependency is imported inside the model loader, so
+these tests run hermetically: the mlx_audio modules are faked at the import
+boundary and the streaming contract is exercised against a scripted model.
+"""
+import asyncio
+import sys
+from types import ModuleType, SimpleNamespace
+
+import numpy as np
+import pytest
+
+from whisperlivekit.timed_objects import SpeakerSegment
+
+
+class FakeStreamingModel:
+    """Scripted stand-in for the mlx-audio streaming sortformer model."""
+
+    def __init__(self, segments_per_chunk=None):
+        self.segments_per_chunk = segments_per_chunk or []
+        self.received_chunks = []
+
+    def init_streaming_state(self):
+        return {"chunk_index": 0}
+
+    def feed(self, chunk, state, sample_rate=16000):
+        self.received_chunks.append(chunk)
+        index = state["chunk_index"]
+        state = {"chunk_index": index + 1}
+        segments = self.segments_per_chunk[index] if index < len(self.segments_per_chunk) else []
+        result = SimpleNamespace(segments=segments)
+        return result, state
+
+
+@pytest.fixture
+def fake_mlx_audio(monkeypatch):
+    """Install a fake mlx_audio package whose load() returns a scripted model."""
+
+    def install(model):
+        vad = ModuleType("mlx_audio.vad")
+        vad.load = lambda repo: model
+        mlx_audio = ModuleType("mlx_audio")
+        mlx_audio.vad = vad
+        monkeypatch.setitem(sys.modules, "mlx_audio", mlx_audio)
+        monkeypatch.setitem(sys.modules, "mlx_audio.vad", vad)
+        model.loaded_repo = None
+        original_load = vad.load
+
+        def load(repo):
+            model.loaded_repo = repo
+            return original_load(repo)
+
+        vad.load = load
+
+    return install
+
+
+def _make_backend(fake_mlx_audio, model, **online_kwargs):
+    from whisperlivekit.diarization.sortformer_mlx_backend import (
+        SortformerMLXDiarization,
+        SortformerMLXDiarizationOnline,
+    )
+
+    fake_mlx_audio(model)
+    shared = SortformerMLXDiarization(model_name="test/repo")
+    assert shared.model.loaded_repo == "test/repo"
+    return SortformerMLXDiarizationOnline(shared_model=shared, **online_kwargs)
+
+
+def test_module_import_is_lazy():
+    """The module must import without mlx_audio in sys.modules (lazy loader)."""
+    import whisperlivekit.diarization.sortformer_mlx_backend as backend
+
+    assert hasattr(backend, "SortformerMLXDiarization")
+    assert hasattr(backend, "SortformerMLXDiarizationOnline")
+
+
+def test_loader_passes_repo_and_online_feeds_chunks(fake_mlx_audio):
+    model = FakeStreamingModel(segments_per_chunk=[[SimpleNamespace(start=0.0, end=5.0, speaker=1)]])
+    online = _make_backend(fake_mlx_audio, model)
+
+    chunk = np.zeros(16000, dtype=np.float32)  # 1s of silence
+    for _ in range(6):
+        online.insert_audio_chunk(chunk)
+
+    new_segments = asyncio.run(online.diarize())
+    assert len(model.received_chunks) == 1  # one full 5s chunk fed
+    assert new_segments == [SpeakerSegment(start=0.0, end=5.0, speaker=1)]
+    assert online.get_segments() == new_segments
+
+
+def test_partial_chunk_is_held_until_full(fake_mlx_audio):
+    model = FakeStreamingModel()
+    online = _make_backend(fake_mlx_audio, model)
+
+    online.insert_audio_chunk(np.zeros(16000 * 3, dtype=np.float32))  # 3s < 5s chunk
+    assert asyncio.run(online.diarize()) == []
+    assert len(model.received_chunks) == 0
+
+    online.insert_audio_chunk(np.zeros(16000 * 2, dtype=np.float32))
+    asyncio.run(online.diarize())
+    assert len(model.received_chunks) == 1
+
+
+def test_max_speakers_filters_segments(fake_mlx_audio):
+    model = FakeStreamingModel(
+        segments_per_chunk=[
+            [
+                SimpleNamespace(start=0.0, end=2.0, speaker=1),
+                SimpleNamespace(start=2.0, end=4.0, speaker=5),
+            ]
+        ]
+    )
+    online = _make_backend(fake_mlx_audio, model, max_speakers=4)
+
+    online.insert_audio_chunk(np.zeros(16000 * 5, dtype=np.float32))
+    new_segments = asyncio.run(online.diarize())
+
+    assert [s.speaker for s in new_segments] == [1]
+    assert all(s.speaker < 4 for s in online.get_segments())
+
+
+def test_close_clears_segments(fake_mlx_audio):
+    model = FakeStreamingModel(segments_per_chunk=[[SimpleNamespace(start=0.0, end=5.0, speaker=1)]])
+    online = _make_backend(fake_mlx_audio, model)
+
+    online.insert_audio_chunk(np.zeros(16000 * 5, dtype=np.float32))
+    asyncio.run(online.diarize())
+    assert online.get_segments()
+
+    online.close()
+    assert online.get_segments() == []
+
+
+def test_config_accepts_mlx_sortformer_with_max_speakers():
+    from whisperlivekit.config import WhisperLiveKitConfig
+
+    config = WhisperLiveKitConfig(diarization_backend="mlx-sortformer", sortformer_max_speakers=2)
+    assert config.diarization_backend == "mlx-sortformer"
+
+
+def test_config_still_rejects_max_speakers_for_other_backends():
+    from whisperlivekit.config import WhisperLiveKitConfig
+
+    with pytest.raises(ValueError, match="sortformer_max_speakers requires"):
+        WhisperLiveKitConfig(diarization_backend="diart", sortformer_max_speakers=2)
+
+
+def test_online_diarization_factory_wires_mlx_backend(fake_mlx_audio):
+    from types import SimpleNamespace as NS
+
+    from whisperlivekit.core import online_diarization_factory
+    from whisperlivekit.diarization import sortformer_mlx_backend as backend
+
+    model = FakeStreamingModel()
+    fake_mlx_audio(model)
+    shared = backend.SortformerMLXDiarization(model_name="test/repo")
+    args = NS(diarization_backend="mlx-sortformer", sortformer_max_speakers=3)
+
+    online = online_diarization_factory(args, shared)
+
+    assert isinstance(online, backend.SortformerMLXDiarizationOnline)
+    assert online.max_speakers == 3

--- a/whisperlivekit/config.py
+++ b/whisperlivekit/config.py
@@ -81,6 +81,7 @@ class WhisperLiveKitConfig:
     disable_punctuation_split: bool = False
     diarization_backend: str = "sortformer"
     sortformer_model_path: Optional[str] = None
+    sortformer_mlx_model: str = "mlx-community/diar_streaming_sortformer_4spk-v2.1-fp16"
     backend_policy: str = "simulstreaming"
     backend: str = "auto"
 
@@ -217,9 +218,10 @@ class WhisperLiveKitConfig:
                 raise ValueError(
                     "sortformer_max_speakers must be an integer between 1 and 4."
                 )
-            if self.diarization_backend != "sortformer":
+            if self.diarization_backend not in ("sortformer", "mlx-sortformer"):
                 raise ValueError(
-                    "sortformer_max_speakers requires diarization_backend=sortformer."
+                    "sortformer_max_speakers requires diarization_backend=sortformer "
+                    "or mlx-sortformer."
                 )
 
         # .en model suffix forces English for Whisper-family backends.

--- a/whisperlivekit/core.py
+++ b/whisperlivekit/core.py
@@ -289,6 +289,12 @@ class TranscriptionEngine:
             elif config.diarization_backend == "sortformer":
                 from whisperlivekit.diarization.sortformer_backend import SortformerDiarization
                 self.diarization_model = SortformerDiarization(model_path=config.sortformer_model_path)
+            elif config.diarization_backend == "mlx-sortformer":
+                from whisperlivekit.diarization.sortformer_mlx_backend import SortformerMLXDiarization
+                self.diarization_model = SortformerMLXDiarization(
+                    model_name=config.sortformer_mlx_model,
+                    model_path=config.sortformer_model_path,
+                )
 
         self.translation_model = None
         if config.target_language:
@@ -509,6 +515,12 @@ def online_diarization_factory(args, diarization_backend):
     elif args.diarization_backend == "sortformer":
         from whisperlivekit.diarization.sortformer_backend import SortformerDiarizationOnline
         online = SortformerDiarizationOnline(
+            shared_model=diarization_backend,
+            max_speakers=getattr(args, "sortformer_max_speakers", None),
+        )
+    elif args.diarization_backend == "mlx-sortformer":
+        from whisperlivekit.diarization.sortformer_mlx_backend import SortformerMLXDiarizationOnline
+        online = SortformerMLXDiarizationOnline(
             shared_model=diarization_backend,
             max_speakers=getattr(args, "sortformer_max_speakers", None),
         )

--- a/whisperlivekit/diarization/sortformer_mlx_backend.py
+++ b/whisperlivekit/diarization/sortformer_mlx_backend.py
@@ -1,0 +1,119 @@
+"""MLX-native Sortformer diarization backend (pure MLX via mlx-audio).
+
+A drop-in alternative to the NeMo-based SortformerDiarization that runs entirely
+on Apple Silicon without NeMo, ONNX, or network access. Uses the mlx-community
+MLX conversion of nvidia/diar_streaming_sortformer_4spk-v2.1.
+
+The API mirrors the NeMo backend: a shared model holder (SortformerMLXDiarization)
++ a per-session online processor (SortformerMLXDiarizationOnline) with
+``process(audio)`` → speaker segments and ``get_segments()``.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import List, Optional
+
+import numpy as np
+
+from whisperlivekit.timed_objects import SpeakerSegment
+
+logger = logging.getLogger(__name__)
+
+
+class SortformerMLXDiarization:
+    """Shared model holder for the MLX Sortformer diarization backend.
+
+    Loads the mlx-community MLX conversion once; the online processor reuses
+    the loaded model across sessions.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "mlx-community/diar_streaming_sortformer_4spk-v2.1-fp16",
+        model_path: Optional[str] = None,
+    ):
+        from mlx_audio.vad import load as load_vad
+
+        repo = model_path or model_name
+        logger.info("Loading MLX Sortformer diarization model %s ...", repo)
+        self.model = load_vad(repo)
+        self.model_name = repo
+        logger.info("MLX Sortformer loaded.")
+
+
+class SortformerMLXDiarizationOnline:
+    """Per-session streaming diarization via the MLX Sortformer.
+
+    Feeds audio chunks to ``model.feed(chunk, state)`` and accumulates speaker
+    segments. The caller polls ``get_segments()`` for the current diarization
+    state (mirrors the NeMo backend's contract).
+    """
+
+    def __init__(
+        self,
+        shared_model: SortformerMLXDiarization,
+        sample_rate: int = 16000,
+        max_speakers: Optional[int] = None,
+    ):
+        self.sample_rate = sample_rate
+        self.max_speakers = max_speakers
+        self._model = shared_model.model
+        self._state = self._model.init_streaming_state()
+        self._segments: List[SpeakerSegment] = []
+        self._lock = threading.Lock()
+        self._buffer_audio = np.array([], dtype=np.float32)
+        self._chunk_duration = 5.0  # seconds per diarize() call
+
+    def insert_audio_chunk(self, pcm_array: np.ndarray):
+        """Buffer incoming audio chunks (called from the diarization processor)."""
+        self._buffer_audio = np.concatenate([self._buffer_audio, np.asarray(pcm_array, dtype=np.float32)])
+
+    def insert_silence(self, silence_duration: Optional[float]):
+        """Mark silence (no-op for MLX sortformer — it handles silence internally)."""
+        pass
+
+    async def diarize(self) -> List[SpeakerSegment]:
+        """Process buffered audio and return new speaker segments.
+
+        Feeds audio in chunk_duration-second chunks to the MLX model's streaming
+        API, accumulates segments, and returns them. Called from the audio
+        processor's diarization loop."""
+        threshold = int(self._chunk_duration * self.sample_rate)
+        new_segments: List[SpeakerSegment] = []
+
+        while len(self._buffer_audio) >= threshold:
+            chunk = self._buffer_audio[:threshold]
+            self._buffer_audio = self._buffer_audio[threshold:]
+
+            result, self._state = self._model.feed(
+                chunk, self._state, sample_rate=self.sample_rate
+            )
+
+            if result and result.segments:
+                for seg in result.segments:
+                    spk = seg.speaker
+                    if self.max_speakers is not None and spk is not None and spk >= self.max_speakers:
+                        continue
+                    new_segments.append(
+                        SpeakerSegment(
+                            start=round(seg.start, 2),
+                            end=round(seg.end, 2),
+                            speaker=spk,
+                        )
+                    )
+
+        with self._lock:
+            self._segments.extend(new_segments)
+
+        return new_segments
+
+    def get_segments(self) -> List[SpeakerSegment]:
+        """Get a copy of all accumulated speaker segments."""
+        with self._lock:
+            return list(self._segments)
+
+    def close(self):
+        """Clear accumulated state."""
+        with self._lock:
+            self._segments.clear()

--- a/whisperlivekit/parse_args.py
+++ b/whisperlivekit/parse_args.py
@@ -111,7 +111,7 @@ def build_parser():
         "--diarization-backend",
         type=str,
         default="sortformer",
-        choices=["sortformer", "diart"],
+        choices=["sortformer", "diart", "mlx-sortformer"],
         help="The diarization backend to use.",
     )
 


### PR DESCRIPTION
feat: MLX-native sortformer diarization backend (pure MLX, no NeMo)

## Summary

The existing `sortformer` diarization backend requires NeMo plus a `.nemo`
model download, which is heavy and fails offline. This PR adds
`mlx-sortformer`: the same streaming Sortformer model running through
mlx-audio's MLX conversion
(`mlx-community/diar_streaming_sortformer_4spk-v2.1-fp16`), entirely on
Apple Silicon, with no NeMo, no ONNX, and no network access after the
first cache.

The backend mirrors the NeMo backend's contract exactly
(`insert_audio_chunk` / `insert_silence` / `diarize` / `get_segments` /
`close`), so the pipeline's diarization loop treats it as a peer. It is
selected with `--diarization-backend mlx-sortformer` and wired in the same
two places as the other backends (engine init and the per-session
factory). Speaker capping (`sortformer_max_speakers`) works the same as
for the NeMo backend.

mlx-audio is an optional extra (`diarization-mlx-sortformer`, Apple
Silicon only) and is imported inside the model loader, so the package
imports cleanly without it.

## User impact

- New backend choice; no existing behavior changes. `sortformer` and
  `diart` behave exactly as before, including the `sortformer_max_speakers`
  validation (now also accepting `mlx-sortformer`, since the MLX backend
  applies the same cap).
- On Apple Silicon with the extra installed, diarization runs fully
  offline on MLX.

## Validation

- New tests (`tests/test_diarization_mlx_backend.py`, hermetic: the
  mlx-audio import boundary is faked, no model download): the streaming
  contract (chunk accumulation, feed at chunk size, segment accumulation,
  max-speaker filter, close), the lazy-import property, config validation
  parity, and the factory wiring. 8 tests.
- Live smoke on Apple Silicon with the real model: the full 31.5s zh→en
  test clip processed at RTF 0.024 through the ported contract, 12
  segments, single speaker correctly identified end to end.
- `uv run pytest -q tests/ --ignore=tests/test_pipeline.py`: failure and
  error set identical to `main` (compared run-to-run in the same checkout;
  the pre-existing canary, deepgram, and qwen3-shim failures are
  environmental). The new tests all pass.
- `ruff check .`: passes.

## Checklist

- [x] I searched for an existing issue or discussion and linked it when
      relevant. (No existing issue covers an MLX-native diarization
      backend.)
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-facing changes. (The backend is
      discoverable through `--diarization-backend --help`; a README mention
      can follow.)
- [x] I ran `ruff check .`.
- [x] I ran the relevant pytest suite.
- [x] I did not commit credentials, model weights, generated caches, or
      private data.
